### PR TITLE
Correct Filters and true FFT convolution.

### DIFF
--- a/source/cloud_analysis.py
+++ b/source/cloud_analysis.py
@@ -4,28 +4,31 @@ Created on Wed May 15 09:46:31 2019
 
 @author: Peter Clark
 """
-import os 
+import os
 import netCDF4
 from netCDF4 import Dataset
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
+import scipy.special as sp
+import math as m
 
 import subfilter as sf
 import filters as filt
 import difference_ops as do
 from thermodynamics_constants import *
 import thermodynamics as th
-dir = 'C:/Users/paclk/OneDrive - University of Reading/Git/python/Subfilter/test_data/BOMEX/'
+#dir = 'C:/Users/paclk/OneDrive - University of Reading/Git/python/Subfilter/test_data/BOMEX/'
+dir = 'C:/Users/paclk/OneDrive - University of Reading/traj_data/r15/'
 destdir = dir
-file = 'diagnostics_ts_18000.0.nc'
-ref_file = 'diagnostics_ts_18000.0.nc'
+file = 'diagnostics_3d_ts_7200.0.nc'
+ref_file = 'diagnostics_ts_7200.0.nc'
 
 #w = dataset.variables['w']
 #var_tvar = w.dimensions[0]
 #var_time = dataset.variables[var_tvar]
 
-plot_dir = 'C:/Users/paclk/OneDrive - University of Reading/Git/python/Subfilter/test_data/BOMEX/plots/' 
+plot_dir = dir+'plots/'
 
 plot_type = '.png'
 data_dir = '' # Directory containing data
@@ -43,15 +46,17 @@ def main():
     dataset = Dataset(dir+file, 'r') # Dataset is the class behavior to open the file
                                  # and create an instance of the ncCDF4 class
     ref_dataset=Dataset(dir + ref_file)
+    w = dataset["w"]
+    print(w.dimensions)
 
 #    sigma_list = [0.5,0.2]
     sigma_list = [0.5]
     width = -1
     dx = 100.0
-    dy = 100.0 
+    dy = 100.0
     filter_name = 'gaussian'
 
-    
+
     var_list = ["w", \
                 "th", \
                 "th_v", \
@@ -60,7 +65,7 @@ def main():
                 "q_cloud_liquid_mass", \
                 "q_total", \
                 ]
-    
+
     var_pair_list = [
                 ["w","w"], \
                 ["w","th"], \
@@ -75,56 +80,57 @@ def main():
                 ["th_L","q_vapour"], \
                 ["th_L","q_cloud_liquid_mass"], \
               ]
-    
+
     opgrid = 'p'
     #
-        
+
     filter_list = list([])
-    
+
     for i,sigma in enumerate(sigma_list):
         filter_id = 'filter_{:02d}'.format(i)
         twod_filter = filt.filter_2d(filter_id,\
                                        filter_name, \
                                        sigma=sigma, width=width, \
                                        delta_x=dx/1000.0)
-            
+
         print(twod_filter)
         filter_list.append(twod_filter)
-        
+
     for twod_filter in filter_list:
-        
+
         print(twod_filter)
-        
+
         derived_dataset_name, derived_data, exists = \
                                             sf.setup_derived_data_file(\
-                                            dir+file, dir, fname, twod_filter, \
+                                            dir+file, destdir, dir + ref_file, \
+                                            fname, twod_filter, \
                                             override = False)
         print(derived_dataset_name)
 
         if exists :
             print('File exists - opened for reading.')
-        else : 
+        else :
             print('Creating derived data file.')
             field_list =sf.filter_variable_list(dataset, ref_dataset, \
                                             derived_data, twod_filter, \
-                                            var_list=var_list, grid = opgrid)    
+                                            var_list=var_list, grid = opgrid)
 #        quad_field_list=list([])
             quad_field_list =sf.filter_variable_pair_list(dataset, \
                                             ref_dataset, \
-                                            derived_data, twod_filter, 
-                                            var_list=var_pair_list, grid = opgrid)        
-        times = derived_data['time_series_50_100.0']
+                                            derived_data, twod_filter,
+                                            var_list=var_pair_list, grid = opgrid)
+        times = derived_data[w.dimensions[0]]
         print(derived_data.variables)
         print(times)
         print(times[:])
 
-        
-#    derived_dataset_name = os.path.basename(file) 
+
+#    derived_dataset_name = os.path.basename(file)
 #    derived_dataset_name = ('.').join(derived_dataset_name.split('.')[:-1])
 #    derived_dataset_name = derived_dataset_name + "_" + \
 #            twod_filter_id + ".nc"
 #    derived_dataset = Dataset(destdir+derived_dataset_name, "r")
-        print(derived_data.variables)    
+        print(derived_data.variables)
         #    derived_data.twod_filter_id = twod_filter.id
         #    derived_data.setncatts(twod_filter.attributes)
         th_L_th_L=derived_data.variables["th_L_th_L_onp"][...]
@@ -149,51 +155,94 @@ def main():
 #        print(p)
         T_L_r = th_L_r * piref
         alpha_L = th.dqsatbydT(T_L_r, p)
-        
+
         print(np.max(alpha_L),np.min(alpha_L))
         a_L = 1.0 / (1.0 + L_over_cp * alpha_L)
         print(np.shape(a_L))
         print(np.max(a_L),np.min(a_L))
-        
+
         Q_cr = a_L*(q_t_r - th.qsat(T_L_r, p))
-        
+
         print(np.max(Q_cr),np.min(Q_cr))
-        plt.figure(1)
-        plt.plot(Q_cr.flatten(), q_cl_r.flatten(),'.',markersize=1)
 #        plt.show()
-        
+
         var_s = a_L * a_L * (qt_qt - 2 * alpha_L * piref * th_L_qt + \
                              alpha_L * alpha_L * piref * piref * th_L_th_L)
-        
+
         sigma_s = np.sqrt(var_s)
         print(np.max(sigma_s),np.min(sigma_s))
-        
+
+        QN = Q_cr / sigma_s
+
+        q_cl_N = q_cl_r / sigma_s
+
         th_L_q_s = alpha_L * piref * th_L_s
-        
+
         s = a_L * (q_t_s - th_L_q_s)
-        
-        print(np.shape(s), np.shape(q_cl_s))
-        
-        plt.figure(2)
-        plt.plot(s.flatten(), q_cl_s.flatten(),'.',markersize=1)
-        plt.show()
+        s_over_sigma_s = s / sigma_s
+
+        QN_c=np.arange(-3,0.3, 0.1)
+        C_MY=0.5*(1+sp.erf(QN_c/m.sqrt(2)))
+        q_cl_MY = C_MY * QN_c + np.exp(-(QN_c**2)/2)/m.sqrt(2*m.pi)
+
+#        print(np.shape(s), np.shape(q_cl_s))
         ilev = 15
-        print(np.min(th_L_q_s),np.max(th_L_q_s))
-        print(np.min(q_t_s),np.max(q_t_s))
-        
-        plt.figure(3)
-        plt.hist2d(th_L_q_s[...,ilev].flatten()*1000, \
-                   q_t_s[...,ilev].flatten()*1000, \
-                   range = [[-0.1,0.1],[-1,1]], bins=(100,100))
-        plt.xlabel(r"$\alpha_L \Pi \theta_L^s (g/kg)$")
-        plt.ylabel(r"$q_t^s (g/kg)$")
-        
+        plt.figure(1)
+        plt.plot(Q_cr[...,ilev].flatten(), q_cl_r[...,ilev].flatten(),'.',markersize=1)
+
+        plt.figure(2)
+        plt.plot(s[...,ilev].flatten(), q_cl_s[...,ilev].flatten(),'.',markersize=1)
         plt.show()
+
+
+        for ilev in range(15,76) :
+            print(zn[ilev])
+#            print(np.min(th_L_q_s),np.max(th_L_q_s))
+#            print(np.min(q_t_s),np.max(q_t_s))
+
+            plt.figure(3)
+            plt.hist2d(th_L_q_s[...,ilev].flatten()*1000, \
+                       q_t_s[...,ilev].flatten()*1000, \
+                       range = [[-0.1,0.1],[-1,1]],bins=(1000,1000))
+            plt.xlabel(r"$\alpha_L \Pi \theta_L^s (g/kg)$")
+            plt.ylabel(r"$q_t^s (g/kg)$")
+            plt.title("Level {:2d} height {:4.0f}".format(ilev,zn[ilev]))
+            plt.savefig(plot_dir+"q_t_v_th_L_{:2d}".format(ilev)+plot_type)
+            plt.close()
+
+#            plt.show()
+            plt.figure(4)
+            plt.hist( s[...,ilev].flatten()*1000, bins=100, density=True)
+    #        plt.xlabel(r"$\alpha_L \Pi \theta_L^s (g/kg)$")
+            plt.xlabel(r"$s^s (g/kg)$")
+            plt.title("Level {:2d} height {:4.0f}".format(ilev,zn[ilev]))
+            plt.savefig(plot_dir+"s_hist_{:2d}".format(ilev)+plot_type)
+            plt.close()
+#            plt.show()
+
+            plt.figure(5)
+            plt.hist( s_over_sigma_s[...,ilev].flatten(), bins=100, density=True)
+    #        plt.xlabel(r"$\alpha_L \Pi \theta_L^s (g/kg)$")
+            plt.xlabel(r"$s^s/\sigma_s$")
+            plt.title("Level {:2d} height {:4.0f}".format(ilev,zn[ilev]))
+            plt.savefig(plot_dir+"s_norm_hist_{:2d}".format(ilev)+plot_type)
+            plt.close()
+
+            plt.figure(6)
+            plt.plot( QN[...,ilev].flatten(),q_cl_N[...,ilev].flatten(),'.',markersize=0.1)
+            plt.plot(QN_c,q_cl_MY,'k')
+            plt.ylabel(r"$q_{cl}N$")
+            plt.xlabel(r"$QN$")
+            plt.title("Level {:2d} height {:4.0f}".format(ilev,zn[ilev]))
+            plt.savefig(plot_dir+"q_cl_vs_QN_{:2d}".format(ilev)+plot_type)
+            plt.close()
+#            plt.show()
+
         derived_data.close()
-        
+
 #    filter_dataset.close()
-    
+
 if __name__ == "__main__":
-    main()    
-    
-    
+    main()
+
+

--- a/source/filters.py
+++ b/source/filters.py
@@ -10,14 +10,15 @@ eps = float_info.min # smallest possible float
 #===============================================================================
 class filter_2d :
     def __init__(self, filter_id, filter_name, wavenumber=-1, \
-                         delta_x=1.0, width=-1,cutoff=0.0001, \
-                         high_pass=0, sigma=-1):
-        '''    Args:
-          filter_name (str): Name of filter used. Either Gaussian, wave-cutoff or 
+                         delta_x=1000.0, width=-1,cutoff=0.0001, \
+                         high_pass=0, sigma=-1, use_ave=False):
+        '''
+		Args:
+          filter_name (str): Name of filter used. Either Gaussian, wave-cutoff or
                              running-mean.
-          wavenumber (float): If a wave-cutoff filter is used, contains the cutoff 
+          wavenumber (float): If a wave-cutoff filter is used, contains the cutoff
                               wavenumber.
-          delta_x (float): Distance between points in the horizontal, 
+          delta_x (float): Distance between points in the horizontal,
                            used to caculate the filter
           width (int): If set, controls the width of the filter. Must be set for
                        running-mean filter.
@@ -30,48 +31,43 @@ class filter_2d :
                             been coded yet!)
           sigma (float): If a Gaussian filter is used, this is the lengthscale of
                          the filter.
-        '''    
-            
+        '''
+
         if (filter_name == 'domain'):
             data = np.ones([1,1])
-         
+
         elif (filter_name == 'gaussian'):
             if (sigma == -1):
-                data = filter_2d_error(filter_name, 'sigma')
+                data = self.filter_2d_error(filter_name, 'sigma')
             else:
-                data = gaussian_filter_2d(sigma, delta_x, cutoff, width)
+                if use_ave :
+                    data = gaussian_filter_2d_ave(sigma, delta_x, cutoff, width)
+                else:
+                    data = gaussian_filter_2d(sigma, delta_x, cutoff, width)
         elif (filter_name == 'running_mean'):
             if (width == -1):
-                data = filter_2d_error(filter_name, 'width')
+                data = self.filter_2d_error(filter_name, 'width')
             else:
                 data = running_mean_filter_2d(width)
         elif (filter_name == 'wave_cutoff'):
             if (wavenumber == -1):
-                data = filter_2d_error(filter_name, 'wavenumber')
+                data = self.filter_2d_error(filter_name, 'wavenumber')
             else:
-                data = wave_cutoff_filter_2d(wavenumber, delta_x, width,
-                                             cutoff, high_pass)     
+                if use_ave :
+                    data = wave_cutoff_filter_2d_ave(wavenumber, delta_x,
+                                             width, cutoff, high_pass)
+                else:
+                    data = wave_cutoff_filter_2d(wavenumber, delta_x, width,
+                                             cutoff, high_pass)
         else:
             print('This filter type is not available.')
             print('Available filters are:')
             print('domain, gaussian, running_mean & wave_cutoff')
             data = -9999
-            
-        if (np.size(np.shape(data)) > 1 ) : 
+
+        if (np.size(np.shape(data)) > 1 ) :
             self.data = data
-            
-#            x = filter_dataset.createDimension('x'+filter_id[6:],np.shape(data)[0])
-#            y = filter_dataset.createDimension('y'+filter_id[6:],np.shape(data)[1])
-#            filter_data = filter_dataset.createVariable(filter_id, "f8",\
-#                                    ("x"+filter_id[6:],"y"+filter_id[6:]))
-#            filter_data[:,:] = data
-#            filter_data.filter_name = filter_name
-#            filter_data.sigma = sigma
-#            filter_data.wavenumber = wavenumber
-#            filter_data.delta_x = delta_x
-#            filter_data.width = width
-#            filter_data.cutoff = cutoff
-#            filter_data.high_pass = high_pass  
+
             self.id = filter_id
             self.attributes = {'filter_type' : filter_name, \
                   'wavenumber' : wavenumber, \
@@ -80,29 +76,29 @@ class filter_2d :
                   'cutoff' : cutoff, \
                   'high_pass' : high_pass, \
                   'sigma' : sigma}
-            
+
     def __str__(self):
         rep = "Filter (2D) id: {0}\n".format(self.id)
 #        rep += self.attributes.__str__()
         for attr in self.attributes:
             rep += "{0}: {1}\n".format(attr, self.attributes[attr])
         return rep
-           
+
     def __repr__(self):
         rep = "filter_2d:"
         rep += " id: {0}, data{1}, attributes{2}\n".format(self.id,\
                      np.shape(self.data), \
                      self.attributes)
         return rep
-    
+
     def filter_2d_error(filter_name, problem):
         '''
         Prints error when parameter required by filter does not exist.
-    
+
         Args:
           filter_name (str): Name of filter
           problem (str): Name of parameter that has not been set
-    
+
         Returns:
           filter_2d (-9999): Error code for filter.
         '''
@@ -110,7 +106,7 @@ class filter_2d :
         print('for the ' + problem + ' was not chosen')
         filter_2d = -9999
         return filter_2d
-    
+
 def running_mean_filter_2d(width):
     '''
     Calculates a square 2D running mean filter with the given width
@@ -139,18 +135,18 @@ def running_mean_filter(width):
     return np.ones(width)/width
 
 
-def wave_cutoff_filter(wavenumber, delta_x=1.0, width=-1, cutoff=0.0001,
+def wave_cutoff_filter(wavenumber, delta_x=1000.0, width=-1, cutoff=0.0001,
                        high_pass=0):
     '''
     Calculates a 1D wave-cutoff filter caculated using the given wavenumber.
-    
+
     Uses filter(x) = sin(wavenumber*x)/x. Normalised by sum(filter(x)).
     Note that this returns the average value of filter(x) over the range
     (x-delta_x/2.0, x+delta_x/2.0).
-    
+
     Args:
       wavenumber (float):
-      delta_x (float, default=1.0): The distance between two points in the data
+      delta_x (float, default=1000.0): The distance between two points in the data
                                     that the filter will be applied to.
       width (int, default=-1): If not -1, used to explicitly set the width of the
                                filter.
@@ -172,7 +168,7 @@ def wave_cutoff_filter(wavenumber, delta_x=1.0, width=-1, cutoff=0.0001,
                 if width/2 == width/2.0:
                     x = np.concatenate((np.arange(width/2)[::-1],
                                         np.arange(width/2)))
-                else:  
+                else:
                     x = np.arange(width)-(width/2)
                 x = x * delta_x
                 result = np.zeros(width)
@@ -186,7 +182,7 @@ def wave_cutoff_filter(wavenumber, delta_x=1.0, width=-1, cutoff=0.0001,
             if width/2 == width/2.0:
                 x = np.concatenate((np.arange(width/2)[::-1],
                                     np.arange(width/2)))
-            else:  
+            else:
                 x = np.arange(width)-(width/2)
             x = x * delta_x
             result = np.zeros(width)
@@ -202,17 +198,77 @@ def wave_cutoff_filter(wavenumber, delta_x=1.0, width=-1, cutoff=0.0001,
         print(' high pass filter not yet coded!')
         return 1.0
 
+def is_npi(x, tol=0.000001):
+    r = np.abs(np.pi*np.round(x/np.pi )- x) <= tol
+    return r
 
-def wave_cutoff_filter_2d(wavenumber, delta_x=1.0, width=-1, cutoff=0.0001,
+def wave_cutoff_filter_2d(wavenumber, delta_x=1000.0, width=-1, cutoff=0.0001,
                           high_pass=0):
     '''
     Calculates a 2D wave-cutoff filter caculated using the given wavenumber.
-    
-    Uses filter(x,y) = sin(wavenumber*x)/x * sin(wavenumber*y)/y. 
+
+    Uses filter(x,y) = sin(wavenumber*x)/x * sin(wavenumber*y)/y.
+    Normalised by sum(filter(x,y)).
+    Note that this returns the point value of filter(x).
+
+    Args:
+      wavenumber (float):
+      delta_x (float, default=1000.0): The distance between two points in the data
+                                    that the filter will be applied to.
+      width (int, default=-1): If not -1, used to explicitly set the width of the
+                               filter.
+      cutoff (float, default=0.0001): If width=-1, the width of the filter is set
+                                      dynamically, and increased until the
+                                      smallest value of the filter is less than
+                                      the cutoff value.
+      high_pass (bool, default=0): If true a high pass filter is calculated
+
+    Returns:
+      ndarray: 2D array of filter values
+    '''
+    if is_npi(wavenumber*delta_x):
+        print("Use fixed width as wavenumber*delta_x = n * pi")
+        return None
+    if width == -1:
+        if is_npi(wavenumber*delta_x):
+            print("Use fixed width as wavenumber*delta_x = n * pi")
+            return None
+
+        half_width = 0
+        result = np.ones((1,1))
+        rmin = 1
+        while rmin > cutoff:
+            half_width += 1
+            L = half_width * delta_x
+            c = np.linspace(-L, L, 2*half_width+1)
+            x, y = np.meshgrid(c, c)
+            x[x == 0] = eps
+            y[y == 0] = eps
+            result = np.sin(wavenumber*x) / x * np.sin(wavenumber*y) / y
+            result /= np.sum(result)
+            rmin = np.abs(result[np.logical_and(~is_npi(wavenumber*y), ~is_npi(wavenumber*y))]).min()
+        width = 2 * half_width+1
+    else:
+        L = (width-1)/2 * delta_x
+        c = np.linspace(-L, L, width)
+        x, y = np.meshgrid(c, c)
+        x[x == 0] = eps
+        y[y == 0] = eps
+        result = np.sin(wavenumber*x) / x * np.sin(wavenumber*y) / y
+        result /= np.sum(result)
+    return result
+
+
+def wave_cutoff_filter_2d_ave(wavenumber, delta_x=1000.0, width=-1, cutoff=0.0001,
+                          high_pass=0):
+    '''
+    Calculates a 2D wave-cutoff filter caculated using the given wavenumber.
+
+    Uses filter(x,y) = sin(wavenumber*x)/x * sin(wavenumber*y)/y.
     Normalised by sum(filter(x,y)).
     Note that this returns the average value of filter(x) over the range
     (x-delta_x/2.0, x+delta_x/2.0).
-    
+
     Args:
       wavenumber (float):
       delta_x (float, default=1.0): The distance between two points in the data
@@ -234,17 +290,17 @@ def wave_cutoff_filter_2d(wavenumber, delta_x=1.0, width=-1, cutoff=0.0001,
             width = 1
             result = np.ones(1).reshape(1,1)
             cutoff = cutoff * pi * pi # multiply cutoff by normalising factor rather than dividing filter each time
-            while abs(result[:(width+1)/2,:(width+1)/2]).min() > cutoff:
+            while abs(result[:(width+1)//2,:(width+1)//2]).min() > cutoff:
                 width  += 2
                 if width/2 == width/2.0:
                     x = np.concatenate((np.arange(width/2)[::-1],
                                         np.arange(width/2)))
-                else:  
+                else:
                     x = np.arange(width)-(width/2)
                 x = x * delta_x
                 result = np.zeros(width**2).reshape(width,width)
-                for i in range((width+1)/2):
-                    for j in range((width+1)/2):
+                for i in range((width+1)//2):
+                    for j in range((width+1)//2):
                         temp1 = np.tile((delta_x*np.arange(n)/(n-1)+x[i]
                                          -(delta_x/2.0)), (n,1))
                         temp2 = np.tile((delta_x*np.arange(n)/(n-1)+x[j]
@@ -254,16 +310,19 @@ def wave_cutoff_filter_2d(wavenumber, delta_x=1.0, width=-1, cutoff=0.0001,
                         temp1[temp1 == 0] = eps
                         temp2[temp2 == 0] = eps
                         result[i, j] = np.mean((np.sin(wavenumber*temp1)/temp1)
-                                               *(np.sin(wavenumber*temp2)/temp2),dtype=np.float64)
+                                     *(np.sin(wavenumber*temp2)/temp2),
+                                     dtype=np.float64)
         else:
-            if width/2 == width/2.0:
-                x = np.concatenate((np.arange(width/2)[::-1], np.arange(width/2)))
-            else:  
-                x = np.arange(width)-(width/2)
+            if width//2 == width/2.0:
+                x = np.concatenate((-np.arange(1,(width+1)//2)[::-1],
+                                    np.arange((width+1)//2)))
+#                x = np.concatenate((np.arange(width//2)[::-1], np.arange(width//2)))
+            else:
+                x = np.arange(width)-(width//2)
             x = x * delta_x
-            result = np.zeros(width**2).reshape(width,width)
-            for i in range((width+1)/2):
-                for j in range((width+1)/2):
+            result = np.zeros((width,width))
+            for i in range((width+1)//2):
+                for j in range((width+1)//2):
                     temp1 = np.tile((delta_x*np.arange(n)/(n-1)+x[i]
                                      -(delta_x/2.0)), (n,1))
                     temp2 = np.tile((delta_x*np.arange(n)/(n-1)+x[j]
@@ -273,10 +332,13 @@ def wave_cutoff_filter_2d(wavenumber, delta_x=1.0, width=-1, cutoff=0.0001,
                     temp1[temp1 == 0] = eps
                     temp2[temp2 == 0] = eps
                     result[i, j] = np.mean((np.sin(wavenumber*temp1)/temp1)
-                                           *(np.sin(wavenumber*temp2)/temp2),dtype=np.float64)
-        temp = result[0:(width+1)/2,0:(width+1)/2]
-        temp = np.concatenate((temp[:,:width/2], temp[:,::-1]),axis=1)
-        result = np.concatenate((temp[:width/2,:], temp[::-1,:]),axis=0)
+                                           *(np.sin(wavenumber*temp2)/temp2),
+                                           dtype=np.float64)
+#                    result[i, j] = (np.sin(wavenumber*temp1)/temp1)\
+#                                  *(np.sin(wavenumber*temp2)/temp2)
+        temp = result[0:(width+1)//2,0:(width+1)//2]
+        temp = np.concatenate((temp[:,:width//2], temp[:,::-1]),axis=1)
+        result = np.concatenate((temp[:width//2,:], temp[::-1,:]),axis=0)
         result = result/np.sum(result)
         return result
     else:
@@ -284,17 +346,17 @@ def wave_cutoff_filter_2d(wavenumber, delta_x=1.0, width=-1, cutoff=0.0001,
         return 1.0
 
 
-def gaussian_filter(sigma, delta_x=1.0, cutoff = 0.0001, width = -1):
+def gaussian_filter(sigma, delta_x=1000.0, cutoff = 0.0001, width = -1):
     '''
     Calculates a 1D Gaussian filter caculated with the given lengthscale (sigma)
-    
+
     Uses filter(x) = EXP(-x^2/2.0*sigma^2). Normalised by sum(filter(x)).
     Note that this returns the average value of filter(x) over the range
     (x-delta_x/2.0, x+delta_x/2.0).
-    
+
     Args:
-      sigma (float): The lengthscale of the filter. 
-      delta_x (float, default=1.0): The distance between two points in the data
+      sigma (float): The lengthscale of the filter.
+      delta_x (float, default=1000.0): The distance between two points in the data
                                     that the filter will be applied to.
       width (int, default=-1): If not -1, used to explicitly set the width of the
                                filter.
@@ -335,16 +397,61 @@ def gaussian_filter(sigma, delta_x=1.0, cutoff = 0.0001, width = -1):
     return result
 
 
-def gaussian_filter_2d(sigma, delta_x=1.0, cutoff=0.0001, width=-1):
+def gaussian_filter_2d(sigma, delta_x=1000.0, cutoff=0.0001, width=-1):
     '''
     Calculates a 2D Gaussian filter caculated with the given lengthscale (sigma)
-    
+
+    Uses filter(x,y) = EXP(-(x+y)^2/2.0*sigma^2). Normalised by sum(filter(x)).
+    Note that this returns the sampled value of filter(x).
+
+    Args:
+      sigma (float): The lengthscale of the filter.
+      delta_x (float, default=1000.0): The distance between two points in the data
+                                    that the filter will be applied to.
+      width (int, default=-1): If not -1, used to explicitly set the width of the
+                               filter.
+      cutoff (float, default=0.0001): If width=-1, the width of the filter is set
+                                      dynamically, and increased until the
+                                      smallest value of the filter is less than
+                                      the cutoff value.
+
+    Returns:
+      ndarray: 2D array of filter values
+    '''
+    if width == -1:
+        half_width = 0
+        result = np.ones((1,1))
+        while result.min() > cutoff:
+            half_width += 1
+            L = half_width * delta_x
+            c = np.linspace(-L, L, 2*half_width+1)
+            x, y = np.meshgrid(c, c)
+            r_sq = x * x + y * y
+            result = np.exp(-r_sq/(2*sigma**2))
+            result /= np.sum(result)
+        width = 2 * half_width+1
+    else:
+        L = (width-1)/2 * delta_x
+        c = np.linspace(-L, L, width)
+        x, y = np.meshgrid(c, c)
+        r_sq = x * x + y * y
+        result = np.exp(-r_sq/(2*sigma**2))
+        result /= np.sum(result)
+
+    print(f"cutoff = {cutoff}, min={np.min(result)}")
+
+    return result
+
+def gaussian_filter_2d_ave(sigma, delta_x=1000.0, cutoff=0.0001, width=-1):
+    '''
+    Calculates a 2D Gaussian filter caculated with the given lengthscale (sigma)
+
     Uses filter(x,y) = EXP(-(x+y)^2/2.0*sigma^2). Normalised by sum(filter(x)).
     Note that this returns the average value of filter(x) over the range
     (x-delta_x/2.0, x+delta_x/2.0).
-    
+
     Args:
-      sigma (float): The lengthscale of the filter. 
+      sigma (float): The lengthscale of the filter.
       delta_x (float, default=1.0): The distance between two points in the data
                                     that the filter will be applied to.
       width (int, default=-1): If not -1, used to explicitly set the width of the
@@ -360,16 +467,16 @@ def gaussian_filter_2d(sigma, delta_x=1.0, cutoff=0.0001, width=-1):
     if width == -1:
         width = 1
         result = np.ones(1).reshape(1,1)
-        cutoff = cutoff * (np.sqrt(2.0 * pi) * sigma)**2
+
         while result[:(width+1)//2,:(width+1)//2].min() > cutoff:
             width += 2
             if width/2 == width/2.0:
-                x = np.concatenate((-np.arange(width/2)[::-1],
-                                    np.arange(width/2)))
-            else:  
+                x = np.concatenate((-np.arange(1,(width+1)//2)[::-1],
+                                    np.arange((width+1)//2)))
+            else:
                 x = np.arange(width)-(width/2)
             x = x * delta_x
-            result = np.zeros(width**2).reshape(width,width)
+            result = np.zeros((width,width))
             for i in range((width+1)//2):
                 for j in range((width+1)//2):
                     temp1 = np.tile((delta_x*np.arange(n)/(n-1)+x[i]
@@ -378,13 +485,15 @@ def gaussian_filter_2d(sigma, delta_x=1.0, cutoff=0.0001, width=-1):
                                      -(delta_x/2.0))**2, (n,1)).transpose()
                     y = temp1 + temp2
                     result[i,j] = np.mean(np.exp(-y / (2.0 * sigma**2)),dtype=np.float64)
+            result /= np.sum(result)
     else:
         if width/2 == width/2.0:
-            x = np.concatenate((-np.arange(width/2)[::-1], np.arange(width/2)))
-        else:  
+            x = np.concatenate((-np.arange(1,(width+1)//2)[::-1],
+                                    np.arange((width+1)//2)))
+        else:
             x = np.arange(width)-(width/2)
         x = x * delta_x
-        result = np.zeros(width**2).reshape(width,width)
+        result = np.zeros((width,width))
         for i in range((width+1)//2):
             for j in range((width+1)//2):
                 temp1 = np.tile((delta_x*np.arange(n)/(n-1)+x[i]
@@ -396,7 +505,7 @@ def gaussian_filter_2d(sigma, delta_x=1.0, cutoff=0.0001, width=-1):
     temp = result[0:(width+1)//2,0:(width+1)//2]
     temp = np.concatenate((temp[:,:width//2], temp[:,::-1]),axis=1)
     result = np.concatenate((temp[:width//2,:], temp[::-1,:]),axis=0)
-    result = result / np.sum(result)
+    result /= np.sum(result)
     return result
 
 

--- a/source/subfilter.py
+++ b/source/subfilter.py
@@ -4,7 +4,7 @@ Created on Tue Oct 23 11:07:05 2018
 
 @author: Peter Clark
 """
-import os 
+import os
 import netCDF4
 
 from netCDF4 import Dataset
@@ -16,96 +16,94 @@ from difference_ops import *
 import time
 from thermodynamics_constants import *
 
-               
-def filter_variable_list(source_dataset, ref_dataset, \
-                         derived_dataset, twod_filter,\
-                         var_list=None, grid='p') :
+test_level = 0
+
+
+def filter_variable_list(source_dataset, ref_dataset, derived_dataset,
+                         options, twod_filter, var_list=None, grid='p') :
     """
-    Create filtered versions of input variables on required grid, stored in derived_dataset.
-    
+    Create filtered versions of input variables on required grid,
+    stored in derived_dataset.
+
     Args:
         source_dataset  : NetCDF dataset for input
-        ref_dataset     : NetCDF dataset for input containing reference profiles
+        ref_dataset     : NetCDF dataset for input containing reference
+                          profiles
         derived_dataset : NetCDF dataset for derived data
-        twod_filter: 2D filter
+        options         : General options e.g. FFT method used.
+        twod_filter     : 2D filter
         var_list=None   : List of variable names.
         default provided by get_default_variable_list()
         grid='p'        : Grid - 'u','v','w' or 'p'
-		
+
     Returns:
         data array.
-		
+
     @author: Peter Clark
-	
-    """ 
+
+    """
+
     if (var_list==None):
         var_list = get_default_variable_list()
         print("Default list:\n",var_list)
     for v in var_list:
-        vard, vdims, varp  = get_data_on_grid(source_dataset, ref_dataset, v, grid)
-        ncvar_r, ncvar_s = filter_field(vard, v, vdims, derived_dataset, \
-                                        twod_filter, grid=grid, \
+        vard, vdims, varp  = get_data_on_grid(source_dataset, ref_dataset, v,
+                                              grid)
+        ncvar_r, ncvar_s = filter_field(vard, v, vdims, derived_dataset,
+                                        options, twod_filter, grid=grid,
                                         three_d=True, sync=False)
-#        plt.plot(np.mean(ncvar_r,axis=(0,1,2)),last_dim(zn))
-#        plt.title(v[0]+"_r")
-#        plt.show()
-#        plt.plot(np.mean(ncvar_s,axis=(0,1,2)),last_dim(zn))
-#        plt.title(v[0]+"_s")
-#        plt.show()
+
     derived_dataset.sync()
     return var_list
-   
-def filter_variable_pair_list(source_dataset, ref_dataset, \
-                              derived_dataset, twod_filter,\
+
+def filter_variable_pair_list(source_dataset, ref_dataset,
+                              derived_dataset, options, twod_filter,
                               var_list=None, grid='p') :
     """
     Create filtered versions of pairs input variables on A grid, stored in derived_dataset.
-    
+
     Args:
         source_dataset  : NetCDF dataset for input
         derived_dataset : NetCDF dataset for derived data
-        twod_filter: 2D filter
+        options         : General options e.g. FFT method used.
+        twod_filter     : 2D filter
         var_list=None   : List of variable names.
         default provided by get_default_variable_pair_list()
-			
+
     Returns:
         var_list.
-		
+
     @author: Peter Clark
-	
-    """     
+
+    """
+
     if (var_list==None):
         var_list = get_default_variable_pair_list()
 #                    ,"v","w","th","q_vapour","q_cloud_liquid_mass"]
         print("Default list:\n",var_list)
-    if grid=='w' : zvar = "z" 
+    if grid=='w' : zvar = "z"
     else : zvar = "zn"
     for v in var_list:
         print("Calculating s({},{})".format(v[0],v[1]))
 #        var = source_dataset[v[0]]
 #        vdims = var.dimensions
-        svar, vdims = quadratic_subfilter(source_dataset, ref_dataset, \
-                                  derived_dataset, \
+        svar, vdims = quadratic_subfilter(source_dataset, ref_dataset,
+                                  derived_dataset, options,
                                   twod_filter, v[0], v[1], grid=grid)
-        
+
         svar_name = "{}_{}_on{}".format(v[0],v[1],grid)
-        
-        if twod_filter.attributes['filter_type'] == 'domain' : 
-            ncsvar = derived_dataset.createVariable(svar_name,"f8",\
+
+        if twod_filter.attributes['filter_type'] == 'domain' :
+            ncsvar = derived_dataset.createVariable(svar_name,"f8",
                                      (vdims[0],zvar,))
         else :
-            ncsvar = derived_dataset.createVariable(svar_name,"f8",\
+            ncsvar = derived_dataset.createVariable(svar_name,"f8",
                                      (vdims[0],vdims[1],vdims[2],zvar,))
         ncsvar[...] = svar
         print(ncsvar)
-#        plt.plot(np.mean(ncvar_r,axis=(0,1,2)),last_dim(zn))
-#        plt.title(v[0]+"_r")
-#        plt.show()
-#        plt.plot(np.mean(ncvar_s,axis=(0,1,2)),last_dim(zn))
-#        plt.title(v[0]+"_s")
-#        plt.show()
+
     derived_dataset.sync()
-    return var_list   
+    return var_list
 
 
 # Flags are: 'u-grid, v-grid, w-grid'
@@ -115,16 +113,38 @@ def get_default_variable_list() :
     Provide default variable list.
        Returns:
            var_list.
-		
+
     @author: Peter Clark
-	
-    
+
+
     """
 
-    var_list = ["u", "v", "w", "th", "th_v", "th_L", \
-               "q_vapour", "q_cloud_liquid_mass", "q_total"]
+    if test_level == 1:
 # For testing
-#    var_list = ["u","w","th", "th_v", "th_L", "q_total"]
+        var_list = [
+            "w",
+            "th_L",
+            ]
+    if test_level == 2:
+# For testing
+        var_list = ["u","w","th", "th_v", "th_L", "q_total"]
+        var_list = [
+            "u",
+            "w",
+            "th_L",
+            "q_total",
+            ]
+    else:
+        var_list = [
+            "u",
+            "v",
+            "w",
+            "th",
+            "th_v",
+            "th_L",
+            "q_vapour",
+            "q_cloud_liquid_mass",
+            "q_total"]
     return var_list
 
 def get_default_variable_pair_list() :
@@ -132,143 +152,246 @@ def get_default_variable_pair_list() :
     Provide default variable pair list.
        Returns:
            var_list.
-		
+
     @author: Peter Clark
-	
-    
+
+
     """
-    var_list = [
-                ["u","u"], \
-                ["u","v"], \
-                ["u","w"], \
-                ["v","v"], \
-                ["v","w"], \
-                ["w","w"], \
-                ["u","th"], \
-                ["v","th"], \
-                ["w","th"], \
-                ["u","th_v"], \
-                ["v","th_v"], \
-                ["w","th_v"], \
-                ["u","th_L"], \
-                ["v","th_L"], \
-                ["w","th_L"], \
-                ["u","q_vapour"], \
-                ["v","q_vapour"], \
-                ["w","q_vapour"], \
-                ["u","q_cloud_liquid_mass"], \
-                ["v","q_cloud_liquid_mass"], \
-                ["w","q_cloud_liquid_mass"], \
-                ["u","q_total"], \
-                ["v","q_total"], \
-                ["w","q_total"], \
-                ["th_L","th_L"], \
-                ["th_L","q_total"], \
-                ["q_total","q_total"], \
-                ["th_L","q_vapour"], \
-                ["th_L","q_cloud_liquid_mass"], \
-              ]
+    if test_level == 1:
 # For testing
-#    var_list = [
-#                ["u","w"], \
-#                ["w","w"], \
-#                ["u","th"], \
-#                ["w","th"], \
-#                ["w","q_total"], \
-#              ]
+        var_list = [
+                ["w","th_L"],
+              ]
+    elif test_level == 2:
+# For testing
+        var_list = [
+                ["u","w"],
+                ["w","w"],
+                ["u","th"],
+                ["w","th"],
+                ["w","th_L"],
+                ["w","q_total"],
+              ]
+    else:
+        var_list = [
+                ["u","u"],
+                ["u","v"],
+                ["u","w"],
+                ["v","v"],
+                ["v","w"],
+                ["w","w"],
+                ["u","th"],
+                ["v","th"],
+                ["w","th"],
+                ["u","th_v"],
+                ["v","th_v"],
+                ["w","th_v"],
+                ["u","th_L"],
+                ["v","th_L"],
+                ["w","th_L"],
+                ["u","q_vapour"],
+                ["v","q_vapour"],
+                ["w","q_vapour"],
+                ["u","q_cloud_liquid_mass"],
+                ["v","q_cloud_liquid_mass"],
+                ["w","q_cloud_liquid_mass"],
+                ["u","q_total"],
+                ["v","q_total"],
+                ["w","q_total"],
+                ["th_L","th_L"],
+                ["th_L","q_total"],
+                ["q_total","q_total"],
+                ["th_L","q_vapour"],
+                ["th_L","q_cloud_liquid_mass"],
+              ]
     return var_list
 
-def convolve(field, twod_filter):
+def convolve(field, options, twod_filter, dims):
     """
     Convolve field filter using fftconvolve using padding.
-	
+
     Args:
         field : 2D field array
+        options         : General options e.g. FFT method used.
         twod_filter: 2D filter array
-    
+
     Returns:
         field convolved with twod_filter
-		
-    @author: Peter Clark
-	
-    """
-	
-    pad_len = int(np.ceil(len(twod_filter)))
-    field = np.pad(field, pad_len, mode='wrap')
-    result = fftconvolve(field, twod_filter, mode='same')
-    return result[pad_len:-pad_len, pad_len:-pad_len]    
 
-def filtered_field_calc(field, twod_filter, three_d=True ):
+    @author: Peter Clark
+
+    """
+    if options['FFT_type'].upper() == 'FFTCONVOLVE':
+
+        pad_len = np.max(np.shape(twod_filter))//2
+        field = np.pad(field, pad_len, mode='wrap')
+        result = fftconvolve(field, twod_filter, mode='same')
+        result = result[pad_len:-pad_len, pad_len:-pad_len]
+
+    elif options['FFT_type'].upper() == 'FFT':
+
+        if len(np.shape(field)) > 2:
+            edims = tuple(np.setdiff1d(np.arange(len(np.shape(field))), dims))
+            twod_filter = np.expand_dims(twod_filter, axis=edims)
+
+        fft_field = np.fft.fft2(field, axes=dims)
+
+        fft_filtered_field = fft_field * twod_filter
+
+        result = np.fft.ifft2(fft_filtered_field, axes=dims)
+        result = result.real
+
+    elif options['FFT_type'].upper() == 'RFFT':
+
+        if len(np.shape(field)) > 2:
+            edims = tuple(np.setdiff1d(np.arange(len(np.shape(field))), dims))
+            twod_filter = np.expand_dims(twod_filter, axis=edims)
+
+        fft_field = np.fft.rfft2(field, axes=dims)
+
+        fft_filtered_field = fft_field * twod_filter
+
+        result = np.fft.irfft2(fft_filtered_field, axes=dims)
+        result = result.real
+
+    return result
+
+def pad_to_len2D(field, newlen, mode='constant'):
+    sf = np.shape(field)
+    padlen = newlen - sf[0]
+    padleft = padlen - padlen//2
+    padright = padlen - padleft
+    padfield = np.pad(field, ((padleft,padright),), mode=mode)
+    return padfield
+
+
+def filtered_field_calc(field, options, twod_filter, three_d=True ):
     """
     Split field into resolved (field_r) and subfilter (field_s).
-    
+    Note: this routine has a deliberate side effect, to store the fft or rfft
+    of the filter in twod_filter for subsequent re-use.
+
     Args:
         field : 2D field
+        options         : General options e.g. FFT method used.
         twod_filter: 2D filter
         three_d=True : if input has 3 dimensions, interpret as a single time. False: if input has 3 dimensions, interpret first as time.
-    
+
     Returns:
         [field_r, field_s]
-		
+
     @author: Peter Clark
-	
-    """    
-	
-    ndims = len(np.shape(field))
-    if twod_filter.attributes['filter_type'] == 'domain' : 
+
+    """
+
+    sh = np.shape(field)
+    ndims = len(sh)
+    if twod_filter.attributes['filter_type'] == 'domain' :
         fshape = np.asarray(field.shape)
-#        print('Filtering')
-#        print(ndims,three_d)
         if ndims == 2 :
             axis=(0,1)
-            si = np.array([1,1]) 
+            si = np.array([1,1])
             for i in range(2,len(fshape)) : si = np.concatenate(\
                           (si,np.array(fshape[i])),axis=None)
         else :
-            axis=(1,2) 
-            si = np.array([fshape[0],1,1]) 
+            axis=(1,2)
+            si = np.array([fshape[0],1,1])
             for i in range(3,len(fshape)) : si = np.concatenate(\
                           (si,np.array(fshape[i])),axis=None)
-#            fshape = fshape[si]
-#            
-#        field_r = np.zeros(fshape)
-        print(si)
-        print(np.shape(field[...]))
-        print(axis)
-        field_r = np.mean(field[...], axis=axis)       
-        print(np.shape(field_r ))
+
+        field_r = np.mean(field[...], axis=axis)
         field_s = field[...] - np.reshape(field_r,si)
-    else :    
-#        field_r = np.zeros(field.size).reshape(field.shape)
-        field_r = np.zeros(field.shape)
-        if ndims == 2 :
-            field_r[:,:] = convolve(field[:,:], twod_filter.data)
-        elif  ndims == 3 :
-            if three_d :
-                for k in range(field.shape[2]) :
-                    field_r[:,:,k] = convolve(field[:,:,k], twod_filter.data)
-            else : # Assume third dimension is time
-                for k in range(field.shape[0]) :
-                    field_r[k,:,:] = convolve(field[k,:,:], twod_filter.data)
-        elif (ndims == 4):
-            for it in range(field.shape[0]) :
-                for k in range(field.shape[3]) :
-                    field_r[it,:,:,k] = convolve(field[it,:,:,k], twod_filter.data)
+    else :
+        print("Filtering using {}".format(options['FFT_type']))
+        if options['FFT_type'].upper() == 'FFTCONVOLVE':
+            field_r = np.zeros(field.shape)
+            dims = (0,1)
+            if ndims == 2 :
+                field_r[:,:] = convolve(field[:,:], options,
+                                        twod_filter.data, dims)
+            elif  ndims == 3 :
+                if three_d :
+                    for k in range(field.shape[2]) :
+                        field_r[:,:,k] = convolve(field[:,:,k], options,
+                                                  twod_filter.data, dims)
+                else : # Assume third dimension is time
+                    for k in range(field.shape[0]) :
+                        field_r[k,:,:] = convolve(field[k,:,:], options,
+                                                  twod_filter.data, dims)
+            elif (ndims == 4):
+                for it in range(field.shape[0]) :
+                    for k in range(field.shape[3]) :
+                        field_r[it,:,:,k] = convolve(field[it,:,:,k], options,
+                                                     twod_filter.data, dims)
+
+        elif options['FFT_type'].upper() == 'FFT':
+            if ndims == 2 :
+                dims = (0,1)
+            elif ndims == 3 :
+                if three_d :
+                    dims = (0,1)
+                else : # Assume third dimension is time
+                    dims = (1,2)
+            elif (ndims == 4):
+                dims = (1,2)
+            else:
+                dims = (0,1)
+
+            if 'fft' not in twod_filter.__dict__:
+                sf = np.shape(twod_filter.data)
+                if sh[dims[0]] != sf[0] or sh[dims[1]] != sf[1]:
+                    padfilt = pad_to_len2D(twod_filter.data, sh[dims[0]])
+                else:
+                    padfilt = twod_filter.data.copy()
+                # This shift of the filter is necessary to get the phase
+                # information right.
+                padfilt = np.fft.ifftshift(padfilt)
+                twod_filter.fft = np.fft.fft2(padfilt)
+
+            field_r = convolve(field, options, twod_filter.fft, dims)
+
+        elif options['FFT_type'].upper() == 'RFFT':
+
+            if ndims == 2 :
+                dims = (0,1)
+            elif ndims == 3 :
+                if three_d :
+                    dims = (0,1)
+                else : # Assume third dimension is time
+                    dims = (1,2)
+            elif (ndims == 4):
+                dims = (1,2)
+            else:
+                dims = (0,1)
+
+            if 'rfft' not in twod_filter.__dict__:
+                sf = np.shape(twod_filter.data)
+                if sh[dims[0]] != sf[0] or sh[dims[1]] != sf[1]:
+                    padfilt = pad_to_len2D(twod_filter.data, sh[dims[0]])
+                else:
+                    padfilt = twod_filter.data.copy()
+                # This shift of the filter is necessary to get the phase
+                # information right.
+                padfilt = np.fft.ifftshift(padfilt)
+                twod_filter.rfft = np.fft.rfft2(padfilt)
+
+            field_r = convolve(field, options, twod_filter.rfft, dims)
+
         field_s = field[...] - field_r
     return [field_r, field_s]
-    
+
 def nc_dimcopy(source_dataset, derived_dataset, dimname) :
     """
-    Copy dimension from source NetCDF dataset to destination 
-    
+    Copy dimension from source NetCDF dataset to destination
+
     Args:
         source_dataset
         derived_dataset
         dimname
-    
+
     Returns:
         dimension
-		
+
     @author: Peter Clark
     """
     v = source_dataset.variables[dimname]
@@ -276,81 +399,87 @@ def nc_dimcopy(source_dataset, derived_dataset, dimname) :
     dv = derived_dataset.createVariable(dimname,"f8",(dimname,))
     dv[:] = last_dim(v[:])
     return dv
-    
-def setup_derived_data_file(source_file, destdir, fname, twod_filter, \
-                            override=False) :
+
+def setup_derived_data_file(source_file, destdir, ref_file, fname,
+                            options, twod_filter, override=False) :
     """
     Create NetCDF dataset for derived data in destdir.
-	
+
     File name is original file name concatenated with twod_filter.id.
-    
+
     Args:
         source_file     : NetCDF file name.
         destdir         : Directory for derived data.
+        options         : General options e.g. FFT method used.
         twod_filter     : Filter
+        options         : General options e.g. FFT method used.
         override=False  : if True force creation of file
-    
+
     Returns:
         derived_dataset_name, derived_dataset
-		
+
     @author: Peter Clark
-    """    
-    derived_dataset_name = os.path.basename(source_file) 
+    """
+    derived_dataset_name = os.path.basename(source_file)
     derived_dataset_name = ('.').join(derived_dataset_name.split('.')[:-1])
     derived_dataset_name = derived_dataset_name + "_" + fname + "_" + \
         twod_filter.id + ".nc"
     exists = os.path.isfile(destdir+derived_dataset_name)
     if exists and not override :
         derived_dataset = Dataset(destdir+derived_dataset_name, "r")
-    else :  
+    else :
         exists = False
         derived_dataset = Dataset(destdir+derived_dataset_name, "w")
-        
+
         derived_dataset.twod_filter_id = twod_filter.id
         derived_dataset.setncatts(twod_filter.attributes)
-        
+        derived_dataset.setncatts(options)
+
         source_dataset = Dataset(source_file,"r")
+        ref_dataset=Dataset(ref_file)
         w = source_dataset["w"]
+        print(w.dimensions)
     #    u = source_dataset["u"]
-    
-        tvar = w.dimensions[0]    
-    
+
+        tvar = w.dimensions[0]
+
         times = nc_dimcopy(source_dataset, derived_dataset, tvar)
-        z = nc_dimcopy(source_dataset, derived_dataset, "z")
-        zn = nc_dimcopy(source_dataset, derived_dataset, "zn")
-        
+
+        z = nc_dimcopy(ref_dataset, derived_dataset, "z")
+        zn = nc_dimcopy(ref_dataset, derived_dataset, "zn")
+
         derived_dataset.createDimension("x",np.shape(w[:])[1])
         x = derived_dataset.createVariable("x","f8",("x",))
         derived_dataset.createDimension("y",np.shape(w[:])[2])
         y = derived_dataset.createVariable("y","f8",("y",))
-      
+
         derived_dataset.sync()
         source_dataset.close()
-       
+
     return derived_dataset_name, derived_dataset, exists
 
 def get_data(source_dataset, ref_dataset, var_name) :
     """
     Extract data from source NetCDF dataset or derived data.
-	
+
 	Currently supported derived data are:
 	'th_L'    : Liquid water potential temperature.
 	'th_v'    : Virtual potential temperature.
-	'q_total' : Total water 
+	'q_total' : Total water
 
     Returns:
     variable, variable_dimensions, variable_grid_properties
-		
+
     @author: Peter Clark
-	   
+
     """
 
-    var_properties = {"u":[True,False,False],\
-                      "v":[False,True,False],\
-                      "w":[False,False,True],\
-                      "th":[False,False,False],\
-                      "q_vapour":[False,False,False],\
-                      "q_cloud_liquid_mass":[False,False,False],\
+    var_properties = {"u":[True,False,False],
+                      "v":[False,True,False],
+                      "w":[False,False,True],
+                      "th":[False,False,False],
+                      "q_vapour":[False,False,False],
+                      "q_cloud_liquid_mass":[False,False,False],
                       }
     print(var_name)
     try :
@@ -358,7 +487,7 @@ def get_data(source_dataset, ref_dataset, var_name) :
         vardim = var.dimensions
         vard = var[...]
         varp = var_properties[var_name]
-        
+
         print(vardim)
         if var_name == 'th' :
             thref = ref_dataset['thref']
@@ -368,50 +497,58 @@ def get_data(source_dataset, ref_dataset, var_name) :
         print("Data not in dataset")
         if var_name == 'th_L' :
 #            rhoref = ref_dataset.variables['rhon'][-1,...]
-            theta, vardim, varp = get_data(source_dataset, ref_dataset, 'th') 
+            theta, vardim, varp = get_data(source_dataset, ref_dataset, 'th')
             pref = ref_dataset.variables['prefn'][-1,...]
             piref = (pref[:]/1.0E5)**kappa
-            q_cl, vd, vp = get_data(source_dataset, ref_dataset, \
-                                    'q_cloud_liquid_mass') 
+            q_cl, vd, vp = get_data(source_dataset, ref_dataset,
+                                    'q_cloud_liquid_mass')
 #            print("Delta theta_L",np.max(L_over_cp * q_cl / piref))
             vard = theta - L_over_cp * q_cl / piref
 #            input("Press enter")
+
         if var_name == 'th_v' :
 #            rhoref = ref_dataset.variables['rhon'][-1,...]
-            theta, vardim, varp = get_data(source_dataset, ref_dataset, 'th') 
+            theta, vardim, varp = get_data(source_dataset, ref_dataset, 'th')
             thref = ref_dataset['thref'][-1,...]
-            q_v, vardim, varp = get_data(source_dataset, ref_dataset, \
-                                         'q_vapour') 
-            q_cl, vd, vp = get_data(source_dataset, ref_dataset, \
-                                    'q_cloud_liquid_mass') 
+            q_v, vardim, varp = get_data(source_dataset, ref_dataset,
+                                         'q_vapour')
+            q_cl, vd, vp = get_data(source_dataset, ref_dataset,
+                                    'q_cloud_liquid_mass')
 #            print("Delta theta_L",np.max(L_over_cp * q_cl / piref))
             vard = theta + thref * (c_virtual * q_v - q_cl)
+
         if var_name == 'q_total' :
 #            rhoref = ref_dataset.variables['rhon'][-1,...]
-            q_v, vardim, varp = get_data(source_dataset, ref_dataset, \
-                                         'q_vapour') 
-            q_cl, vd, vp = get_data(source_dataset, ref_dataset, \
-                                    'q_cloud_liquid_mass') 
+            q_v, vardim, varp = get_data(source_dataset, ref_dataset,
+                                         'q_vapour')
+            q_cl, vd, vp = get_data(source_dataset, ref_dataset,
+                                    'q_cloud_liquid_mass')
             vard = q_v + q_cl
+
+        if var_name == 'buoyancy':
+            th_v, vardim, varp = get_data(source_dataset, ref_dataset, 'th_v')
+            mean_thv = np.mean(th_v, axis = (1,2))
+            varp = grav * (th_v - mean_thv)/mean_thv
+
     return vard, vardim, varp
 
 def get_data_on_grid(source_dataset, ref_dataset, var_name, grid='p') :
     """
-    Read in 3D data from NetCDF file and, where necessary, interpolate to p grid. 
-	
+    Read in 3D data from NetCDF file and, where necessary, interpolate to p grid.
+
     Assumes first dimension is time.
-    
+
     Args:
-        source_dataset  : NetCDF dataset 
+        source_dataset  : NetCDF dataset
         ref_dataset     : NetCDF dataset containing reference profiles.
         var_name        : Name of variable
 		rrid='p'        : Destination grid. 'u', 'v', 'w' or 'p'.
-    
+
     Returns:
         variable_dimensions, variable_grid_properties.
-		
+
     @author: Peter Clark
-    """    
+    """
     var, vdim, vp = get_data(source_dataset, ref_dataset, var_name)
     print(np.shape(var), vdim, vp)
     if grid=='p' :
@@ -423,8 +560,8 @@ def get_data_on_grid(source_dataset, ref_dataset, var_name, grid='p') :
             var = field_on_v_to_p(var, xaxis=1)
         if vp[2] :
             print("Mapping {} from w grid to p grid.".format(var_name))
-            z = source_dataset["z"]
-            zn = source_dataset["zn"]
+            z = ref_dataset["z"]
+            zn = ref_dataset["zn"]
             var = field_on_w_to_p(var,  z, zn)
     elif grid=='u' :
         if not ( vp[0] or vp[1] or vp[2]):
@@ -436,8 +573,8 @@ def get_data_on_grid(source_dataset, ref_dataset, var_name, grid='p') :
             var = field_on_p_to_u(var, xaxis=1)
         if vp[2] :
             print("Mapping {} from w grid to u grid.".format(var_name))
-            z = source_dataset["z"]
-            zn = source_dataset["zn"]
+            z = ref_dataset["z"]
+            zn = ref_dataset["zn"]
             var = field_on_w_to_p(var,  z, zn)
             var = field_on_p_to_u(var, xaxis=1)
     elif grid=='v' :
@@ -450,8 +587,8 @@ def get_data_on_grid(source_dataset, ref_dataset, var_name, grid='p') :
             var = field_on_v_to_p(var, xaxis=1)
         if vp[2] :
             print("Mapping {} from w grid to v grid.".format(var_name))
-            z = source_dataset["z"]
-            zn = source_dataset["zn"]
+            z = ref_dataset["z"]
+            zn = ref_dataset["zn"]
             var = field_on_w_to_p(var,  z, zn)
             var = field_on_p_to_v(var, xaxis=1)
     elif grid=='w' :
@@ -476,25 +613,25 @@ def get_data_on_grid(source_dataset, ref_dataset, var_name, grid='p') :
 def deformation(source_dataset, dx, dy, z, zn, xaxis=0, grid='w') :
     """
     Read in 3D data from NetCDF file and, where necessary, interpolate to p grid.
-	
+
     Assumes first dimension is time.
-    
+
     Args:
-        source_dataset  : NetCDF dataset 
+        source_dataset  : NetCDF dataset
         var_name        : Name of variable
-    
+
     Returns:
         data array.
-		
+
     @author: Peter Clark
-    """     
+    """
     u = source_dataset["u"]
     v = source_dataset["v"]
     w = source_dataset["w"]
     print("u", np.shape(u),u.dimensions)
     print("v", np.shape(v),v.dimensions)
     print("w", np.shape(w),w.dimensions)
-    
+
     ux = d_by_dx_field_on_u(u, dx, z, zn, xaxis=xaxis, grid = grid )
     uy = d_by_dy_field_on_u(u, dy, z, zn, xaxis=xaxis, grid = grid )
     uz = d_by_dz_field_on_u(u, z, zn, xaxis=xaxis, grid = grid )
@@ -502,88 +639,91 @@ def deformation(source_dataset, dx, dy, z, zn, xaxis=0, grid='w') :
     vx = d_by_dx_field_on_v(v, dx, z, zn, xaxis=xaxis, grid = grid )
     vy = d_by_dy_field_on_v(v, dy, z, zn, xaxis=xaxis, grid = grid )
     vz = d_by_dz_field_on_v(v, z, zn, xaxis=xaxis, grid = grid )
-    
+
 
     wx = d_by_dx_field_on_w(w, dx, z, zn, xaxis=xaxis, grid = grid )
     wy = d_by_dy_field_on_w(w, dy, z, zn, xaxis=xaxis, grid = grid )
     wz = d_by_dz_field_on_w(w, z, zn, xaxis=xaxis, grid = grid )
-    
+
     u_i = [ux, uy, uz]
     v_i = [vx, vy, vz]
     w_i = [wx, wy, wz]
-    
+
     t = [u_i, v_i, w_i]
     return t
 
-def filter_field(vard, vname, vdims, derived_dataset, twod_filter, grid='p', \
-                 three_d=True, sync=False) :
+def filter_field(vard, vname, vdims, derived_dataset, options, twod_filter,
+                 grid='p', three_d=True, sync=False) :
     """
     Create filtered versions of input variable on required grid, stored in derived_dataset.
-       
+
     Args:
         derived_dataset : NetCDF dataset for derived data.
+        options         : General options e.g. FFT method used.
         twod_filter     : 2D filter.
         vard            : data array.
         vname           : variable name.
         vdims           : array of variable dimension names.
         default provided by get_default_variable_list()
         grid='p'        : Grid - 'u','v','w' or 'p'
-		
+
     Returns:
         ncvar_r, ncvar_s: Resolved and subfilter fields as netcf variables in
                           derived_dataset.
-						  
+
     @author: Peter Clark
-	
-    """     
-    if grid=='w' : zvar = "z" 
+
+    """
+    if grid=='w' : zvar = "z"
     else : zvar = "zn"
     print(vname)
-    var_r, var_s = filtered_field_calc(vard, twod_filter, three_d=True )
-            
-    if twod_filter.attributes['filter_type'] == 'domain' : 
-        ncvar_r = derived_dataset.createVariable(vname+"_r"+"_on"+grid,"f8",\
+    var_r, var_s = filtered_field_calc(vard, options, twod_filter,
+                                       three_d=True )
+
+    if twod_filter.attributes['filter_type'] == 'domain' :
+        ncvar_r = derived_dataset.createVariable(vname+"_r"+"_on"+grid,"f8",
                                  (vdims[0],zvar,))
     else :
-        ncvar_r = derived_dataset.createVariable(vname+"_r"+"_on"+grid,"f8",\
+        ncvar_r = derived_dataset.createVariable(vname+"_r"+"_on"+grid,"f8",
                                  (vdims[0],vdims[1],vdims[2],zvar,))
-        
+
     ncvar_r[...] = var_r
     print(ncvar_r)
-    ncvar_s = derived_dataset.createVariable(vname+"_s"+"_on"+grid,"f8",\
+    ncvar_s = derived_dataset.createVariable(vname+"_s"+"_on"+grid,"f8",
                                  (vdims[0],vdims[1],vdims[2],zvar,))
     ncvar_s[...] = var_s
     print(ncvar_s)
-    
+
     if sync : derived_dataset.sync()
-    
+
     return ncvar_r, ncvar_s
 
-def filtered_deformation(source_dataset, derived_dataset, twod_filter, \
+def filtered_deformation(source_dataset, derived_dataset, options, twod_filter,
                          dx, dy, z, zn, xaxis=0, grid='p') :
     """
     Create filtered versions of deformation field.
 
     Args:
-        source_dataset  : NetCDF input dataset 
+        source_dataset  : NetCDF input dataset
         derived_dataset : NetCDF dataset for derived data.
+        options         : General options e.g. FFT method used.
         twod_filter     : 2D filter.
         grid='p'        : Grid - 'u','v','w' or 'p'
-		
+
     Returns:
         ncvar_r, ncvar_s: Resolved and subfilter fields as netcf variables in derived_dataset.
-						  
+
     @author: Peter Clark
 
-    """ 
-    
+    """
+
 #:math:`\frac{\partial u_i}{\partial{x_j}`
     u = source_dataset["u"]
     vdims = u.dimensions
     vname = 'deformation'
-        
-    d = deformation(source_dataset, dx, dy, z, zn, xaxis=xaxis, \
-                           grid=grid)  
+
+    d = deformation(source_dataset, dx, dy, z, zn, xaxis=xaxis,
+                           grid=grid)
     d_ij_r = list()
     d_ij_s = list()
     for i in range(3) :
@@ -591,15 +731,15 @@ def filtered_deformation(source_dataset, derived_dataset, twod_filter, \
         d_j_s = list()
         for j in range(3) :
             vn = "{}_{:1d}_{:1d}".format(vname,i,j)
-            def_r, def_s = filter_field(d[i][j], vn, vdims, derived_dataset, \
-                                twod_filter, grid='p', \
+            def_r, def_s = filter_field(d[i][j], vn, vdims, derived_dataset,
+                                options, twod_filter, grid='p',
                                 three_d=True, sync=False)
             d_j_r.append(def_r)
             d_j_s.append(def_s)
         d_ij_r.append(d_j_r)
         d_ij_s.append(d_j_s)
     derived_dataset.sync()
-    
+
     return d_ij_r, d_ij_s
 
 def shear(d, no_trace=True) :
@@ -613,63 +753,64 @@ def shear(d, no_trace=True) :
     for i in range(3) :
         for j in range(i,3) :
             S_ij = d[i][j][...]+d[j][i][...]
-            if i == j : 
+            if i == j :
                 S_ij = S_ij - trace
                 mod_S += 0.5 * S_ij * S_ij
-            else :  
+            else :
                 mod_S +=  S_ij * S_ij
             S["{:1d}_{:1d}".format(i,j)] = (S_ij)
     return S, mod_S
 
 def vorticity(d) :
 
-    V_0 = d[2][1][...]-d[1][2][...] 
-    V_1 = d[0][3][...]-d[3][0][...] 
-    V_2 = d[1][0][...]-d[0][1][...] 
+    V_0 = d[2][1][...]-d[1][2][...]
+    V_1 = d[0][3][...]-d[3][0][...]
+    V_2 = d[1][0][...]-d[0][1][...]
     V = [V_0, V_1, V_2]
-    
-    return V 
 
-def quadratic_subfilter(source_dataset,  ref_dataset, \
-                        derived_dataset, twod_filter,
+    return V
+
+def quadratic_subfilter(source_dataset,  ref_dataset,
+                        derived_dataset, options, twod_filter,
                         v1_name, v2_name, grid='p') :
     """
     Create filtered versions of pair of input variables on required grid, stored in derived_dataset.
-    
+
     Args:
         source_dataset  : NetCDF dataset for input
         derived_dataset : NetCDF dataset for derived data
-        twod_filter: 2D filter
+        options         : General options e.g. FFT method used.
+        twod_filter     : 2D filter
         v1_name, v2_name: Variable names.
-    
+
     Returns:
         s(var1,var2) data array.
-        vdims dimensions of var1 
-        
-		
+        vdims dimensions of var1
+
+
     @author: Peter Clark
-	
+
     """
-    vard1, vd1, vp1 = get_data_on_grid(source_dataset,  ref_dataset, \
+    vard1, vd1, vp1 = get_data_on_grid(source_dataset,  ref_dataset,
                                        v1_name, grid=grid)
     print("Reading ", v1_name+"_r"+"_on"+grid)
     var1_r = derived_dataset[v1_name+"_r"+"_on"+grid]
-    
+
     vdims = var1_r.dimensions
-    
+
     print(np.shape(var1_r))
-        
-    vard2, vd2, vp2 = get_data_on_grid(source_dataset,  ref_dataset, \
+
+    vard2, vd2, vp2 = get_data_on_grid(source_dataset,  ref_dataset,
                                        v2_name, grid=grid)
     print("Reading ", v2_name+"_r"+"_on"+grid)
     var2_r = derived_dataset[v2_name+"_r"+"_on"+grid]
     print(np.shape(var2_r))
-    
+
     var1var2 = vard1 * vard2
-    var1var2_r, var1var2_s = filtered_field_calc(var1var2, twod_filter, \
-                                                 three_d=True )
-    
+    var1var2_r, var1var2_s = filtered_field_calc(var1var2, options,
+                                                 twod_filter, three_d=True )
+
     var1var2 = var1var2_r - var1_r[...] * var2_r[...]
-    
+
     return var1var2, vdims
-    
+

--- a/source/subfilter_file.py
+++ b/source/subfilter_file.py
@@ -4,7 +4,7 @@ Created on Tue Oct 23 11:27:25 2018
 
 @author: Peter Clark
 """
-import os 
+import os
 import netCDF4
 from netCDF4 import Dataset
 import numpy as np
@@ -15,8 +15,19 @@ import subfilter as sf
 import filters as filt
 import difference_ops as do
 
+options = {
+#        'FFT_type': 'FFTconvolve',
+#        'FFT_type': 'FFT',
+        'FFT_type': 'RFFT',
+          }
+
 
 dir = 'C:/Users/paclk/OneDrive - University of Reading/Git/python/Subfilter/test_data/BOMEX/'
+odir = 'C:/Users/paclk/OneDrive - University of Reading/Git/python/Subfilter/test_data/BOMEX/'
+odir = odir + 'test_op_' + options['FFT_type']+'/'
+
+os.makedirs(odir, exist_ok = True)
+
 file = 'diagnostics_ts_18000.0.nc'
 ref_file = 'diagnostics_ts_18000.0.nc'
 
@@ -24,60 +35,58 @@ ref_file = 'diagnostics_ts_18000.0.nc'
 #var_tvar = w.dimensions[0]
 #var_time = dataset.variables[var_tvar]
 
-plot_dir = 'C:/Users/paclk/OneDrive - University of Reading/Git/python/Subfilter/test_data/BOMEX/plots/' 
+plot_dir = odir + 'plots/'
+os.makedirs(plot_dir, exist_ok = True)
 
 plot_type = '.png'
 data_dir = '' # Directory containing data
 figshow = True
 
 def plot_field(var_name, derived_data, twod_filter, ilev, iy, grid='p'):
-    
+
     var_r = derived_data[var_name+"_r_on"+grid]
     var_s = derived_data[var_name+"_s_on"+grid]
-   
-    
+
+
     for it in range(var_r.shape[0]):
         if twod_filter.attributes['filter_type']=='domain' :
             zcoord = sf.last_dim(derived_data[var_r.dimensions[1]])
             pltdat = (var_r[it,:])
-        
+
             fig1, axa = plt.subplots(1,1,figsize=(5,5))
-        
+
     #    plt.subplot(3, 2, 1)
             Cs1 = axa.plot(pltdat, zcoord)
             axa.set_xlabel(r'%s$^r$'%(var_name))
             axa.set_ylabel('z')
-    
+
             plt.tight_layout()
-        
+
             plt.savefig(plot_dir+var_name+'_prof_'+\
                     twod_filter.id+'_%02d'%it+plot_type)
             plt.close()
-        else : 
+        else :
             zcoord = sf.last_dim(derived_data[var_r.dimensions[3]])
             meanfield= np.mean(var_r[it,...],axis=(0,1),keepdims=True)
             pltdat = (var_r[it,...]-meanfield)
-        
-            lev1 = np.arange(-10,10.1,0.1)
-            lev2 = np.arange(-10,10.1,0.1)
-            
+
             nlevels = 40
             plt.clf
-        
+
             fig1, axa = plt.subplots(3,2,figsize=(10,12))
-            
+
         #    plt.subplot(3, 2, 1)
             Cs1 = axa[0,0].contourf(np.transpose(pltdat[:, :, ilev]),\
                      nlevels)
             axa[0,0].set_title(r'%s$^r$ pert level %03d'%(var_name,ilev))
             axa[0,0].set_xlabel('x')
-        
+
         # Make a colorbar for the ContourSet returned by the contourf call.
             cbar1 = fig1.colorbar(Cs1,ax=axa[0,0])
             cbar1.ax.set_ylabel(var_name)
         # Add the contour line levels to the colorbar
         #  cbar.add_lines(CS2)
-        
+
         #    plt.subplot(3, 2, 2)
             Cs2 = axa[0,1].contourf(np.transpose(var_s[it, :, :, ilev]),\
                      nlevels)
@@ -103,21 +112,21 @@ def plot_field(var_name, derived_data, twod_filter, ilev, iy, grid='p'):
         ## Make a colorbar for the ContourSet returned by the contourf call.
             cbar4 = fig1.colorbar(Cs4,ax=axa[1,1])
             cbar4.ax.set_ylabel(var_name)
-        #    
+        #
             x=(np.arange(0,var_r.shape[2])-0.5*var_r.shape[2])*0.1
         #    plt.subplot(3, 2, 5)
             ax1 = axa[2,0].plot(x,pltdat[:,iy,ilev])
-        #    
+        #
         #    plt.subplot(3, 2, 6)
             ax2 = axa[2,1].plot(x,var_s[it,:,iy,ilev])
-        #    
+        #
             plt.tight_layout()
-            
+
             plt.savefig(plot_dir+var_name+'_lev_'+'%03d'%ilev+'_x_z'+'%03d'%iy+'_'+\
                         twod_filter.id+'_%02d'%it+plot_type)
             plt.close()
-        
-            
+
+
     #
     #    plt.show()
     #plt.close()
@@ -125,31 +134,31 @@ def plot_field(var_name, derived_data, twod_filter, ilev, iy, grid='p'):
     return
 
 def plot_quad_field(var_name, derived_data, twod_filter, ilev, iy, grid='p'):
-    
+
     v1 = var_name[0]
     v2 = var_name[1]
-    
+
     v1_r = derived_data[v1+"_r_on"+grid]
     v2_r = derived_data[v2+"_r_on"+grid]
-        
+
     print(v1,v2)
     s_v1v2 = derived_data["{}_{}_on{}".format(v1,v2,grid)]
-    
+
     for it in range(s_v1v2.shape[0]):
-        
+
         if twod_filter.attributes['filter_type']=='domain' :
             pltdat = (s_v1v2[it,:])
             zcoord = sf.last_dim(derived_data[v1_r.dimensions[1]])
-        
+
             fig1, axa = plt.subplots(1,1,figsize=(5,5))
-        
+
     #    plt.subplot(3, 2, 1)
             Cs1 = axa.plot(pltdat, zcoord)
             axa.set_xlabel('s({},{})'.format(v1,v2))
             axa.set_ylabel('z')
-    
+
             plt.tight_layout()
-        
+
             plt.savefig(plot_dir+var_name[0]+'_'+var_name[1]+'_prof_'+\
                     twod_filter.id+'_%02d'%it+plot_type)
             plt.close()
@@ -157,30 +166,30 @@ def plot_quad_field(var_name, derived_data, twod_filter, ilev, iy, grid='p'):
             zcoord = sf.last_dim(derived_data[v1_r.dimensions[3]])
             var_r = (v1_r[it,...] - np.mean(v1_r[it,...], axis=(0,1))) * \
                     (v2_r[it,...] - np.mean(v2_r[it,...], axis=(0,1)))
-                    
+
             meanfield= np.mean(var_r[...],axis=(0,1),keepdims=True)
             pltdat = (var_r[...]-meanfield)
-        
-            lev1 = np.arange(-10,10.1,0.1)
-            lev2 = np.arange(-10,10.1,0.1)
-            
+
+#            lev1 = np.arange(-10,10.1,0.1)
+#            lev2 = np.arange(-10,10.1,0.1)
+
             nlevels = 40
             plt.clf
-        
+
             fig1, axa = plt.subplots(3,2,figsize=(10,12))
-            
+
         #    plt.subplot(3, 2, 1)
             Cs1 = axa[0,0].contourf(np.transpose(pltdat[:, :, ilev]),\
                      nlevels)
             axa[0,0].set_title(r'{}$^r${}$^r$ pert level {:03d}'.format(v1, v2,ilev))
             axa[0,0].set_xlabel('x')
-        
+
         # Make a colorbar for the ContourSet returned by the contourf call.
             cbar1 = fig1.colorbar(Cs1,ax=axa[0,0])
             cbar1.ax.set_ylabel(var_name)
         # Add the contour line levels to the colorbar
         #  cbar.add_lines(CS2)
-        
+
         #    plt.subplot(3, 2, 2)
             Cs2 = axa[0,1].contourf(np.transpose(s_v1v2[it, :, :, ilev]),\
                      nlevels)
@@ -206,20 +215,20 @@ def plot_quad_field(var_name, derived_data, twod_filter, ilev, iy, grid='p'):
         ## Make a colorbar for the ContourSet returned by the contourf call.
             cbar4 = fig1.colorbar(Cs4,ax=axa[1,1])
             cbar4.ax.set_ylabel(var_name)
-        #    
+        #
             x=(np.arange(0,var_r.shape[1])-0.5*var_r.shape[1])*0.1
         #    plt.subplot(3, 2, 5)
             ax1 = axa[2,0].plot(x,pltdat[:,iy,ilev])
-        #    
+        #
         #    plt.subplot(3, 2, 6)
             ax2 = axa[2,1].plot(x,s_v1v2[it,:,iy,ilev])
-        #    
+        #
             plt.tight_layout()
-            
+
             plt.savefig(plot_dir+var_name[0]+'_'+var_name[1]+'_lev_'+'%03d'%ilev+'_x_z'+'%03d'%iy+'_'+\
                         twod_filter.id+'_%02d'%it+plot_type)
             plt.close()
-        
+
     #
     #    plt.show()
     #plt.close()
@@ -235,42 +244,39 @@ def plot_shear(var_r, var_s, zcoord,  twod_filter, ilev, iy, no_trace = True):
 #        pltdat = (var_r[it,...]-meanfield)
         if twod_filter.attributes['filter_type']=='domain' :
             pltdat = (var_r[it,:])
-        
+
             fig1, axa = plt.subplots(1,1,figsize=(5,5))
-        
+
     #    plt.subplot(3, 2, 1)
             Cs1 = axa.plot(pltdat[1:], zcoord[1:])
             axa.set_xlabel(var_name)
             axa.set_ylabel('z')
-    
+
             plt.tight_layout()
-        
+
             plt.savefig(plot_dir+var_name+'_prof_'+\
                     twod_filter.id+'_%02d'%it+plot_type)
             plt.close()
         else :
             pltdat = var_r[it,...]
-        
-            lev1 = np.arange(-10,10.1,0.1)
-            lev2 = np.arange(-10,10.1,0.1)
-            
+
             nlevels = 40
             plt.clf
-        
+
             fig1, axa = plt.subplots(3,2,figsize=(10,12))
-            
+
         #    plt.subplot(3, 2, 1)
             Cs1 = axa[0,0].contourf(np.transpose(pltdat[:, :, ilev]),\
                      nlevels)
             axa[0,0].set_title(r'%s$^r$ level %03d'%(var_name,ilev))
             axa[0,0].set_xlabel('x')
-        
+
         # Make a colorbar for the ContourSet returned by the contourf call.
             cbar1 = fig1.colorbar(Cs1,ax=axa[0,0])
             cbar1.ax.set_ylabel(var_name)
         # Add the contour line levels to the colorbar
         #  cbar.add_lines(CS2)
-        
+
         #    plt.subplot(3, 2, 2)
             Cs2 = axa[0,1].contourf(np.transpose(var_s[it, :, :, ilev]),\
                      nlevels)
@@ -296,20 +302,20 @@ def plot_shear(var_r, var_s, zcoord,  twod_filter, ilev, iy, no_trace = True):
         ## Make a colorbar for the ContourSet returned by the contourf call.
             cbar4 = fig1.colorbar(Cs4,ax=axa[1,1])
             cbar4.ax.set_ylabel(var_name)
-        #    
+        #
             x=(np.arange(0,var_r.shape[2])-0.5*var_r.shape[2])*0.1
         #    plt.subplot(3, 2, 5)
             ax1 = axa[2,0].plot(x,pltdat[:,iy,ilev])
-        #    
+        #
         #    plt.subplot(3, 2, 6)
             ax2 = axa[2,1].plot(x,var_s[it,:,iy,ilev])
-        #    
+        #
             plt.tight_layout()
-            
+
             plt.savefig(plot_dir+var_name+'_lev_'+'%03d'%ilev+'_x_z'+'%03d'%iy+'_'+\
                         twod_filter.id+'_%02d'%it+plot_type)
             plt.close()
-        
+
     #
     #    plt.show()
 #    plt.close()
@@ -323,25 +329,25 @@ def main():
 #   Non-global variables that are set once
 #    sigma_list = [0.2,0.25,0.3,0.4,0.8,1.0,1.5,2.0] # Sigma used in Gaussian filter function
 #    sigma_list = [2.0] # Sigma used in Gaussian#
-    sigma_list = [0.5,0.2]
+    sigma_list = [500.0, 200.0]
     width = -1
     dx = 100.0
-    dy = 100.0 
+    dy = 100.0
     filter_name = 'gaussian'
 #    width = 20
-#    filter_name = 'running_mean'   
-    
+#    filter_name = 'running_mean'
+
     dataset = Dataset(dir+file, 'r') # Dataset is the class behavior to open the file
                                  # and create an instance of the ncCDF4 class
     ref_dataset = Dataset(dir+ref_file, 'r')
     ilev = 15
-    iy = 40 
-    
+    iy = 40
+
     opgrid = 'w'
     fname = 'test_plot'
 #
 # Just looking at anyhb at present
-    
+
     filter_list = list([])
 
     for i,sigma in enumerate(sigma_list):
@@ -349,109 +355,101 @@ def main():
         twod_filter = filt.filter_2d(filter_id,\
                                    filter_name, \
                                    sigma=sigma, width=width, \
-                                   delta_x=dx/1000.0)
-        
+                                   delta_x=dx)
+
         print(twod_filter)
         filter_list.append(twod_filter)
-        
+
 # Add whole domain filter
     filter_name = 'domain'
-    filter_id = 'filter_{:02d}'.format(len(filter_list))    
-    twod_filter = filt.filter_2d(filter_id, filter_name, delta_x=dx/1000.0)
+    filter_id = 'filter_{:02d}'.format(len(filter_list))
+    twod_filter = filt.filter_2d(filter_id, filter_name, delta_x=dx)
     filter_list.append(twod_filter)
-        
+
     print(filter_list)
-    
+
     z = do.last_dim(dataset["z"])
     zn = do.last_dim(dataset["zn"])
-    
+
     for twod_filter in filter_list:
-        
+
         print(twod_filter)
-        
-        derived_dataset_name, derived_data, exists = sf.setup_derived_data_file(\
-                                            dir+file, dir, fname, twod_filter,\
-                                            override=True)
+
+        derived_dataset_name, derived_data, exists = \
+            sf.setup_derived_data_file( dir+file, odir, dir+ref_file, fname,
+                                       options, twod_filter, override=True)
+        print("Variables in derived dataset.")
         print(derived_data.variables)
         exists = False
         if exists :
             print('Derived data file exists' )
         else :
 
-            field_list =sf.filter_variable_list(dataset, ref_dataset, \
-                                                derived_data, twod_filter, \
-                                                var_list=None, grid = opgrid)    
+            field_list =sf.filter_variable_list(dataset, ref_dataset,
+                                                derived_data, options,
+                                                twod_filter, var_list=None,
+                                                grid = opgrid)
     #        quad_field_list=list([])
-            quad_field_list =sf.filter_variable_pair_list(dataset, ref_dataset, \
-                                                derived_data, twod_filter, 
-                                                var_list=None, grid = opgrid)        
-        
-        
-#        print(np.shape(z))
-#        print(np.shape(zn))
-#        print(z)
-#        print(zn)
-#        t = sf.deformation(dataset, dx, dy, z, zn, xaxis=1, grid='w')
-        
-            d_r, d_s = sf.filtered_deformation(dataset, derived_data, twod_filter,\
-                             dx, dy, z, zn, xaxis=1, grid='w')
-            
+            quad_field_list =sf.filter_variable_pair_list(dataset, ref_dataset,
+                                                derived_data, options,
+                                                twod_filter, var_list=None,
+                                                grid = opgrid)
+
+
+            d_r, d_s = sf.filtered_deformation(dataset, derived_data, options,
+                                               twod_filter, dx, dy, z, zn,
+                                               xaxis=1, grid='w')
+
             times = derived_data['time_series_50_100.0']
             print(times)
             print(times[:])
             for i in range(3) :
                 for j in range(3) :
                     print(d_r[i][j],d_s[i][j])
-            
+
             Sn_ij_r, mod_Sn_r = sf.shear(d_r)
             Sn_ij_s, mod_Sn_s = sf.shear(d_s)
             S_ij_r, mod_S_r = sf.shear(d_r, no_trace = False)
             S_ij_s, mod_S_s = sf.shear(d_s, no_trace = False)
             print(S_ij_r.keys())
 #        input("Press enter")
-        
+
         z = derived_data["z"]
-#        print("z",np.shape(z[:]))   
-#        print(z[:])
         zn = derived_data["zn"]
-#        print("zn",np.shape(zn[:]))   
-#        print(zn[:])
-#        uv = sf.quadratic_subfilter(dataset, derived_data, twod_filter,\
-#                        "u", "v")
-#        uvm = np.mean(uv,axis=(0,1,2))
-#        plt.plot(np.mean(uv,axis=(0,1,2)),zn[:])
-#        plt.plot(uvm,zn[:])
-#        plt.show()
-        
-        u_r = derived_data["u_r_on"+opgrid]
-        print(u_r)
+
+#        u_r = derived_data["u_r_on"+opgrid]
+#        print(u_r)
 #        os.remove(derived_dataset_name)
 #        print twod_filter
         if twod_filter.attributes['filter_type']!='domain' :
             fig1 = plt.figure(1)
-            plt.contourf(twod_filter.data,20) 
-            
+            plt.contourf(twod_filter.data,20)
+            plt.savefig(plot_dir+'Filter_'+\
+                        twod_filter.id+plot_type)
+            plt.close()
+
             fig2 = plt.figure(2)
             plt.plot(twod_filter.data[np.shape(twod_filter.data)[0]//2,:])
-            plt.show()
-        
+            plt.savefig(plot_dir+'Filter_y_xsect_'+\
+                        twod_filter.id+plot_type)
+            plt.close()
+
         for field in field_list:
             print("Plotting {}".format(field))
-            plot_field(field, derived_data, twod_filter, ilev, iy, grid=opgrid)            
+            plot_field(field, derived_data, twod_filter, ilev, iy, grid=opgrid)
 
         for field in quad_field_list :
             print("Plotting {}".format(field))
             plot_quad_field(field, derived_data, twod_filter, ilev, iy, \
-                            grid=opgrid)    
-            
+                            grid=opgrid)
+
         plot_shear(mod_Sn_r, mod_Sn_s, z, twod_filter, ilev, iy, no_trace = True)
         plot_shear(mod_S_r, mod_S_s, z, twod_filter, ilev, iy, no_trace = False)
-        
-        
+
 #        test_filter(dataset, twod_filter)
         derived_data.close()
-        
+        dataset.close()
 #    filter_dataset.close()
-    
+
 if __name__ == "__main__":
     main()

--- a/source/test_filters.py
+++ b/source/test_filters.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Sep 15 16:10:18 2020
+
+@author: paclk
+"""
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+
+import subfilter as sf
+import filters as filt
+import difference_ops as do
+
+options = {
+#       'FFT_type': 'FFTconvolve',
+#       'FFT_type': 'FFT',
+       'FFT_type': 'RFFT',
+          }
+
+
+sigma_list = [2000.0, 1000.0, 500.0, 200.0, 100.0]
+#sigma_list = [2000.0]
+dx = 100.0
+
+filter_name = 'gaussian'
+#filter_name = 'wave_cutoff'
+#filter_name = 'running_mean'
+filter_list = list([])
+
+N = 128
+dx = 100
+
+cxy = np.linspace(0,(N-1)*dx,N )
+
+xc, yc = np.meshgrid(cxy,cxy)
+
+Lx = (N)*dx/3
+Ly = (N)*dx/10
+
+kx = 2.0 * np.pi / Lx
+ky = 2.0 * np.pi / Ly
+
+field = np.cos(kx * xc)*np.cos(ky * yc)
+levs=np.linspace(-1,1,41)
+
+xc /= 1000
+yc /= 1000
+
+cxy /= 1000
+
+
+
+for i,sigma in enumerate(sigma_list):
+    filter_id = 'filter_{:02d}'.format(i)
+    width = min(N, int(np.ceil( sigma/dx *4)*2+1))
+ #   width = -1
+    twod_filter = filt.filter_2d(filter_id,
+                                 filter_name, wavenumber=2*np.pi/sigma,
+                                 sigma=sigma, width=width,
+                                 delta_x=dx, use_ave=False)
+    twod_filter_ave = filt.filter_2d(filter_id,
+                                 filter_name, wavenumber=2*np.pi/sigma,
+                                 sigma=sigma, width=width,
+                                 delta_x=dx, use_ave=True)
+
+    print(twod_filter)
+    filter_list.append([twod_filter, twod_filter_ave])
+
+
+print(filter_list)
+
+for twod_filter, twod_filter_ave in filter_list:
+
+    print(np.sum(twod_filter.data), np.sum(twod_filter_ave.data))
+
+#    f = plt.figure()
+    nx, ny = np.shape(twod_filter.data)
+
+    x = np.linspace(-(nx//2), nx//2, nx) * twod_filter.attributes['delta_x']/1000
+
+    nx1, ny1 = np.shape(twod_filter_ave.data)
+
+    x1 = np.linspace(-(nx1//2), nx1//2, nx1) * twod_filter.attributes['delta_x']/1000
+
+    f, ax = plt.subplots(2,2,figsize=(12,12))
+
+    c = ax[0,0].contour(x, x, twod_filter.data,20,colors='blue')
+    c1 = ax[0,0].contour(x1, x1, twod_filter_ave.data,20,colors='red')
+    ax[0,0].set_xlabel("x/km")
+    ax[0,0].set_ylabel("y/km")
+
+#    ax[0,0].legend()
+
+
+    p1 = ax[0,1].plot(x, twod_filter.data[nx//2, :],label='Sampled')
+    p1 = ax[0,1].plot(x1, twod_filter_ave.data[nx1//2, :],label='Averaged')
+    ax[0,1].set_xlabel("x/km")
+    ax[0,1].legend()
+    p2 = ax[1,0].plot(x, twod_filter.data[:, ny//2],label='Sampled')
+    p2 = ax[1,0].plot(x1, twod_filter_ave.data[:, ny1//2],label='Averaged')
+    ax[1,0].set_xlabel("x/km")
+    ax[1,0].legend()
+    p3 = ax[1,1].plot(x*np.sqrt(2),twod_filter.data.diagonal(),label='Sampled')
+    p3 = ax[1,1].plot(x1*np.sqrt(2),twod_filter_ave.data.diagonal(),label='Averaged')
+    ax[1,1].set_xlabel("x/km")
+    ax[1,1].legend()
+    plt.tight_layout()
+
+
+    field_r, field_s = sf.filtered_field_calc(field, options, twod_filter, three_d=False )
+
+    E_field = np.mean(field * field)
+    E_field_r = np.mean(field_r * field_r)
+    E_field_s = np.mean(field_s * field_s)
+
+    fc, axc = plt.subplots(3,3,figsize=(12,12))
+
+
+    c_f = axc[0,0].contourf(xc, yc, field, levs)
+    axc[0,0].set_xlabel("x/km")
+    axc[0,0].set_ylabel("y/km")
+    axc[0,0].set_title(r"Field E={:1.4f}".format(E_field))
+
+    c_r = axc[1,0].contourf(xc, yc, field_r, levs)
+    axc[1,0].set_xlabel("x/km")
+    axc[1,0].set_ylabel("y/km")
+    axc[1,0].set_title(r"Field$^r$ E={:1.4f}".format(E_field_r))
+
+    c_s = axc[2,0].contourf(xc, yc, field_s, levs)
+    axc[2,0].set_xlabel("x/km")
+    axc[2,0].set_ylabel("y/km")
+    axc[2,0].set_title(r"Field$^s$ E={:1.4f}".format(E_field_s))
+
+    px_f = axc[0,1].plot(cxy, field[N//2,:])
+    axc[0,1].set_title(r"$1/(k_x\sigma)$={:3.2f}".format(1/(kx*twod_filter.attributes['sigma'])))
+    axc[0,1].set_xlabel("x/km")
+    px_r = axc[1,1].plot(cxy, field_r[N//2,:])
+    axc[1,1].set_xlabel("x/km")
+    px_s = axc[2,1].plot(cxy, field_s[N//2,:])
+    axc[2,1].set_xlabel("x/km")
+
+    py_f = axc[0,2].plot(cxy, field[:, N//2])
+    axc[0,2].set_ylabel("y/km")
+    axc[0,2].set_title(r"$1/(k_y\sigma)$={:3.2f}".format(1/(ky*twod_filter.attributes['sigma'])))
+    py_r = axc[1,2].plot(cxy, field_r[:, N//2])
+    axc[1,0].set_ylabel("y/km")
+    py_s = axc[2,2].plot(cxy, field_s[:, N//2])
+    axc[2,2].set_ylabel("y/km")
+
+    plt.tight_layout()
+
+
+plt.show()

--- a/source/test_signal.py
+++ b/source/test_signal.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Sep 16 10:39:06 2020
+
+@author: paclk
+"""
+import numpy as np
+from scipy import signal
+import matplotlib.pyplot as plt
+
+N = 129
+omega = 6.0 * 2.0 * np.pi/N
+
+s = np.cos(omega * np.arange(N))
+
+Fs = np.fft.fft(s)
+
+
+#w = np.fft.ifftshift(signal.gaussian(N, 5.0,sym=False))
+w = signal.gaussian(N, 5.0,sym=False)
+w = w/np.sum(w)
+
+plt.plot(w)
+plt.show()
+
+Fw = np.fft.fft( np.fft.ifftshift(w))
+plt.plot(np.fft.fftfreq(N),Fw.real)
+plt.plot(np.fft.fftfreq(N),Fw.imag)
+plt.show()
+
+
+
+s_f = signal.fftconvolve(s, w, mode='same')
+Fs_f = np.fft.fft(s_f)
+
+s_f2 = np.fft.ifft(Fs * Fw )
+
+plt.plot(s,label='original')
+plt.plot(s_f,label='FFTconvolve')
+plt.plot(s_f2.real, label = 'FFT')
+plt.legend()
+plt.show()
+
+plt.plot(np.fft.fftfreq(N),Fs.real, label ='Fs real')
+plt.plot(np.fft.fftfreq(N),Fs.imag, label ='Fs imag')
+plt.plot(np.fft.fftfreq(N),Fs_f.real, label ='Fs_f real')
+plt.plot(np.fft.fftfreq(N),Fs_f.imag, label ='Fs_f imag')
+plt.legend()
+plt.show()
+

--- a/source/test_signal_real.py
+++ b/source/test_signal_real.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Sep 16 10:39:06 2020
+
+@author: paclk
+"""
+import numpy as np
+from scipy import signal
+import matplotlib.pyplot as plt
+
+N = 128
+omega = 6.0 * 2.0 * np.pi/N
+
+s = np.cos(omega * np.arange(N))
+
+Fs = np.fft.rfft(s)
+
+
+#w = np.fft.ifftshift(signal.gaussian(N, 5.0,sym=False))
+w = signal.gaussian(N, 5.0,sym=False)
+w = w/np.sum(w)
+
+plt.plot(w)
+plt.plot(np.fft.ifftshift(w))
+plt.show()
+
+Fw = np.fft.rfft( np.fft.ifftshift(w))
+plt.plot(np.fft.rfftfreq(N),Fw.real)
+plt.plot(np.fft.rfftfreq(N),Fw.imag)
+plt.show()
+
+
+pad_len=N//2
+field = np.pad(s, pad_len, mode='wrap')
+result = signal.fftconvolve(field, w, mode='same')
+s_f = result[pad_len+1:-(pad_len-1)]
+
+#s_f = signal.fftconvolve(s, w, mode='same')
+Fs_f = np.fft.rfft(s_f)
+
+s_f2 = np.fft.irfft(Fs * Fw )
+
+plt.plot(s,label='original')
+plt.plot(s_f,label='FFTconvolve')
+plt.plot(s_f2.real, label = 'FFT')
+plt.legend()
+plt.show()
+
+plt.plot(np.fft.rfftfreq(N),Fs.real, label ='Fs real')
+plt.plot(np.fft.rfftfreq(N),Fs.imag, label ='Fs imag')
+plt.plot(np.fft.rfftfreq(N),Fs_f.real, label ='Fs_f real')
+plt.plot(np.fft.rfftfreq(N),Fs_f.imag, label ='Fs_f imag')
+plt.legend()
+plt.show()
+
+plt.plot(s_f2/s)
+plt.plot(s_f/s)
+plt.ylim([-1,1])
+plt.show()


### PR DESCRIPTION
The Gaussian and wave_cutoff filters were written to average the filter over gridboxes. This has been removed, though previous behaviour is available via keyword.
Note, 1D versions have not yet been changed, as they are  not used in application code. WIll get round to it sometime.

New options to use fft2 or rfft2 in convolve (with filter fft for rfft saved for efficiency) have been implemented. Selected via
options = {'FFT_type': 'FFT' }
or
options = { 'FFT_type': 'RFFT' }

Previous behaviour (not recommended) selectable via
options = { 'FFT_type': 'FFTconvolve' }

Note changes to argument lists to include options.

See 'subfilter_file.py' for example of use.
Now files test_signal.py, test_signal_real.py and test_filters are for testing filter implementations - note last in particular.