### PR TITLE
Convert to using xarray and dask.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,9 @@ target/
 # pyenv
 .python-version
 
+# dask
+source/dask-worker-space/
+
 # celery beat schedule file
 celerybeat-schedule
 

--- a/sandpit/test_xarray.py
+++ b/sandpit/test_xarray.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Mar 16 09:34:26 2021
+
+@author: paclk
+"""
+
+import os
+import sys
+#import netCDF4
+
+#from netCDF4 import Dataset
+
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+import subfilter as sf
+
+#dir = 'C:/Users/paclk/OneDrive - University of Reading/Git/python/Subfilter/test_data/BOMEX/'
+dir = 'C:/Users/paclk/OneDrive - University of Reading/ug_project_data/Data/'
+#odir = 'C:/Users/paclk/OneDrive - University of Reading/Git/python/Subfilter/test_data/BOMEX/'
+odir = 'C:/Users/paclk/OneDrive - University of Reading/ug_project_data/Data/'
+odir = odir + 'test_xarray/'
+
+os.makedirs(odir, exist_ok = True)
+
+#file = 'diagnostics_ts_18000.0.nc'
+file = 'diagnostics_3d_ts_21600.nc'
+
+ofile ='diagnostics_3d_ts_21600_test_xarray.nc'
+
+#ref_file = 'diagnostics_ts_18000.0.nc'
+
+
+dataset = xr.open_dataset(dir+file)
+
+print(dataset)
+
+print(dataset.coords)
+
+od = sf.options_database(dataset)
+#print(od)
+
+derived_dataset = xr.Dataset(coords=dataset.coords)
+
+for var in dataset.variables:
+    if var in dataset.coords:
+        print(var, " is a coord.")
+    else:
+        print(var)
+        d = dataset[var]
+
+#        print(d)
+        if 'x' in d.dims:
+            nx = d.shape[d.dims.index('x')]
+            ny = d.shape[d.dims.index('y')]
+
+            if var == 'u' :
+                x = (np.arange(nx) + 0.5) * np.float64(od['dxx'])
+                xn = 'x_u'
+            else:
+                x = np.arange(nx) * np.float64(od['dxx'])
+                xn = 'x_p'
+
+            if var == 'v' :
+                y = (np.arange(ny) + 0.5) * np.float64(od['dyy'])
+                yn = 'y_v'
+            else:
+                y = np.arange(ny) * np.float64(od['dyy'])
+                yn = 'y_p'
+
+
+            dr = d.rename({'x':xn, 'y':yn})
+
+            dr.coords[xn] = x
+            dr.coords[yn] = y
+#            print(dr)
+            derived_dataset[var] = dr
+
+#print(dataset)
+print(derived_dataset)
+
+# print(derived_dataset)
+
+# derived_dataset.to_netcdf(odir+ofile)
+
+# for var in dataset.variables:
+#     if var in dataset.coords:
+#         print(var, " is a coord.")
+#     else:
+#         print(var)
+#         d = dataset[var]
+
+#         if 'x' in d.dims:
+
+
+#             nx = d.shape[d.dims.index('x')]
+
+#             x_t = np.arange(nx) * np.float64(od['dxx'])
+
+#             dr = d.rename({'x':'x_t'})
+
+#             dr.coords['x_t'] = x_t
+
+#             derived_dataset[var+'_m'] = dr
+#     #        dat = dataset[var].values
+
+#             derived_dataset.to_netcdf(odir+ofile)
+
+# print(derived_dataset)
+
+# print(derived_dataset['u_m'])

--- a/source/plot_dataset.py
+++ b/source/plot_dataset.py
@@ -7,96 +7,13 @@ Created on Tue Oct 23 09:52:58 2018
 
 @author: Peter Clark
 """
-import os 
-import netCDF4
-from netCDF4 import Dataset
+import os
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
-from netCDF4 import Dataset
-
-import subfilter
-
-def print_ncattr(nc_fid,key):
-    """
-    Prints the NetCDF file attributes for a given key
-
-    Parameters
-    ----------
-    key : unicode
-        a valid netCDF4.Dataset.variables key
-    """
-    try:
-        print "\t\ttype:", repr(nc_fid.variables[key].dtype)
-        for ncattr in nc_fid.variables[key].ncattrs():
-            print '\t\t%s:' % ncattr,\
-                  repr(nc_fid.variables[key].getncattr(ncattr))
-    except KeyError:
-        print "\t\tWARNING: %s does not contain variable attributes" % key
-
-def ncattrprint(nc_fid) :
-    # Attribute information
-    nc_attrs = nc_fid.ncattrs()
-    print "NetCDF Global Attributes:"
-    for nc_attr in nc_attrs:
-        print '\t%s:' % nc_attr, repr(nc_fid.getncattr(nc_attr))
+import xarray as xr
 
 
-def ncdimprint(nc_fid) :
-   # Dimension shape information.
-    nc_dims = [dim for dim in nc_fid.dimensions]  # list of nc dimensions
-    print "NetCDF dimension information:"
-    for dim in nc_dims:
-        print "\tName:", dim 
-        print "\t\tsize:", len(nc_fid.dimensions[dim])
-        print_ncattr(nc_fid,dim)
-
-def ncvarprint(nc_fid) :
-    # Variable information.
-    nc_dims = [dim for dim in nc_fid.dimensions]  # list of nc dimensions
-    nc_vars = [var for var in nc_fid.variables]  # list of nc variables
-    print "NetCDF variable information:"
-    for var in nc_vars:
-        if var not in nc_dims :
- #       if (var not in nc_dims) and  (len(nc_fid.variables[var].dimensions) == 4) :
-            print '\tName:', var
-            print "\t\tdimensions:", nc_fid.variables[var].dimensions
-            print "\t\tsize:", nc_fid.variables[var].size
-            print_ncattr(nc_fid,var)
-
-
-def ncdump(nc_fid, verb=True):
-    '''
-    ncdump outputs dimensions, variables and their attribute information.
-    The information is similar to that of NCAR's ncdump utility.
-    ncdump requires a valid instance of Dataset.
-
-    Parameters
-    ----------
-    nc_fid : netCDF4.Dataset
-        A netCDF4 dateset object
-    verb : Boolean
-        whether or not nc_attrs, nc_dims, and nc_vars are printed
-
-    Returns
-    -------
-    nc_attrs : list
-        A Python list of the NetCDF file global attributes
-    nc_dims : list
-        A Python list of the NetCDF file dimensions
-    nc_vars : list
-        A Python list of the NetCDF file variables
-    '''
-
-    # NetCDF global attributes
-    nc_attrs = nc_fid.ncattrs()
-    nc_dims = [dim for dim in nc_fid.dimensions]  # list of nc dimensions
-    nc_vars = [var for var in nc_fid.variables]  # list of nc variables
-    if verb:
-        ncattrprint(nc_fid)
-        ncdimprint(nc_fid)
-        ncvarprint(nc_fid)        
-    return nc_attrs, nc_dims, nc_vars
 
 #dir = 'C:/Users/paclk/OneDrive - University of Reading/python/SG/'
 #file = 'diagnostics_ts_14400.0.nc'
@@ -104,38 +21,29 @@ def ncdump(nc_fid, verb=True):
 #file = 'diagnostics_ts_18000.0.nc'
 #file = 'diagnostics_ts_18000.0_filter_00.nc'
 
-dir = '/gws/nopw/j04/paracon_rdg/users/toddj/MONC_RCE_1.5/MONC_RCE_1.5_m1600_g0084/diagnostic_files/'
-file = 'diagnostics_ts_4784400.0.nc'
+#dir = '/gws/nopw/j04/paracon_rdg/users/toddj/MONC_RCE_1.5/MONC_RCE_1.5_m1600_g0084/diagnostic_files/'
+#dir = 'C:/Users/paclk/OneDrive - University of Reading/Git/python/Subfilter/test_data/BOMEX/'
+#dir = 'C:/Users/paclk/OneDrive - University of Reading/ug_project_data/Data/'
+#dir = 'C:/Users/paclk/OneDrive - University of Reading/ug_project_data/Data/test_dask_RFFT/'
+dir = 'C:/Users\paclk\OneDrive - University of Reading/traj_data/CBL/test_dask_RFFT/'
+#file = 'diagnostics_ts_4784400.0.nc'
+#file = 'diagnostics_ts_18000.0.nc'
+#file = 'diagnostics_3d_ts_21600.nc'
+#file = 'diagnostics_3d_ts_21600_test_dask.nc'
+#file = 'diagnostics_3d_ts_21600_test_dask_filter_ga00.nc'
+file = 'diagnostics_3d_ts_13200_test_dask_filter_ga00.nc'
 
-dataset = Dataset(dir+file, 'r') # Dataset is the class behavior to open the file
-                                 # and create an instance of the ncCDF4 class
+dataset = xr.open_dataset(dir+file,chunks={'time':1,'i':1,'j':1,
+                                                'x_p':160, 'y_p':160,
+                                                'z':'auto'})
+print(dataset)
+fig, axes = plt.subplots(ncols=2, figsize=(12,6))
+d_r = dataset['deformation_r']
+print(d_r)
+d_r.isel(i=0, j=0, time=0, z=10).plot(ax=axes[0])
+d_s = dataset['deformation_s']
+print(d_s)
+d_s.isel(i=0, j=0, time=0, z=10).plot(ax=axes[1])
+plt.show()
+dataset.close()
 
-nc_attrs, nc_dims, nc_vars = ncdump(dataset,verb=True)
-
-#ncdimprint(dataset)
-#ncvarprint(dataset)
-
-#w = dataset.variables['w_r']
-w = dataset.variables['w']
-
-w_tvar = w.dimensions[0]
-w_time = dataset.variables[w_tvar]
-print w.shape
-print w_tvar
-print w_time.dtype
-
-#iz = 20
-#for i in range(0,w.shape[0]):
-#    fig = plt.figure(i)
-#    plt.contourf(w[i,:,:,iz],20)
-#    
-#plt.show()
-
-
-    
-
-#for variable in dataset.variables :
-#    print(variable, variable.dimension())
-    #vars(variable)
- #   print variable
-#    print dataset.variables[variable].dimensions

--- a/source/print_dataset.py
+++ b/source/print_dataset.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+"""
+
+  plot_dataset.py
+
+Created on Tue Oct 23 09:52:58 2018
+
+@author: Peter Clark
+"""
+import os
+import netCDF4
+from netCDF4 import Dataset
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+from netCDF4 import Dataset
+import xarray as xr
+
+import subfilter
+
+def print_ncattr(nc_fid,key):
+    """
+    Prints the NetCDF file attributes for a given key
+
+    Parameters
+    ----------
+    key : unicode
+        a valid netCDF4.Dataset.variables key
+    """
+    try:
+        print("\t\ttype:", nc_fid.variables[key].dtype)
+        for ncattr in nc_fid.variables[key].ncattrs():
+            print('\t\t',ncattr,':',
+                  nc_fid.variables[key].getncattr(ncattr))
+    except KeyError:
+        print(f"\t\tWARNING: {key} does not contain variable attributes")
+
+def ncattrprint(nc_fid) :
+    # Attribute information
+    nc_attrs = nc_fid.ncattrs()
+    print("NetCDF Global Attributes:")
+    for nc_attr in nc_attrs:
+        print('\t',nc_attr,':', nc_fid.getncattr(nc_attr))
+
+
+def ncdimprint(nc_fid) :
+   # Dimension shape information.
+    nc_dims = [dim for dim in nc_fid.dimensions]  # list of nc dimensions
+    print("NetCDF dimension information:")
+    for dim in nc_dims:
+        print(f"\tName: {dim}")
+        print(f"\t\tsize: {len(nc_fid.dimensions[dim])}")
+        print_ncattr(nc_fid,dim)
+
+def ncvarprint(nc_fid) :
+    # Variable information.
+    nc_dims = [dim for dim in nc_fid.dimensions]  # list of nc dimensions
+    nc_vars = [var for var in nc_fid.variables]  # list of nc variables
+    print("NetCDF variable information:")
+    for var in nc_vars:
+        if var not in nc_dims :
+ #       if (var not in nc_dims) and  (len(nc_fid.variables[var].dimensions) == 4) :
+            print(f"\tName: {var}")
+            print("\t\tdimensions:", nc_fid.variables[var].dimensions)
+            print("\t\tsize:", nc_fid.variables[var].size)
+            print_ncattr(nc_fid,var)
+
+
+def ncdump(nc_fid, verb=True):
+    '''
+    ncdump outputs dimensions, variables and their attribute information.
+    The information is similar to that of NCAR's ncdump utility.
+    ncdump requires a valid instance of Dataset.
+
+    Parameters
+    ----------
+    nc_fid : netCDF4.Dataset
+        A netCDF4 dateset object
+    verb : Boolean
+        whether or not nc_attrs, nc_dims, and nc_vars are printed
+
+    Returns
+    -------
+    nc_attrs : list
+        A Python list of the NetCDF file global attributes
+    nc_dims : list
+        A Python list of the NetCDF file dimensions
+    nc_vars : list
+        A Python list of the NetCDF file variables
+    '''
+
+    # NetCDF global attributes
+    nc_attrs = nc_fid.ncattrs()
+    nc_dims = [dim for dim in nc_fid.dimensions]  # list of nc dimensions
+    nc_vars = [var for var in nc_fid.variables]  # list of nc variables
+    if verb:
+        ncattrprint(nc_fid)
+        ncdimprint(nc_fid)
+        ncvarprint(nc_fid)
+    return nc_attrs, nc_dims, nc_vars
+
+#dir = 'C:/Users/paclk/OneDrive - University of Reading/python/SG/'
+#file = 'diagnostics_ts_14400.0.nc'
+#dir = 'C:/Users/paclk/OneDrive - University of Reading/python/subfilter/test_data/BOMEX/'
+#file = 'diagnostics_ts_18000.0.nc'
+#file = 'diagnostics_ts_18000.0_filter_00.nc'
+
+#dir = '/gws/nopw/j04/paracon_rdg/users/toddj/MONC_RCE_1.5/MONC_RCE_1.5_m1600_g0084/diagnostic_files/'
+#dir = 'C:/Users/paclk/OneDrive - University of Reading/Git/python/Subfilter/test_data/BOMEX/'
+#dir = 'C:/Users/paclk/OneDrive - University of Reading/ug_project_data/Data/'
+#dir = 'C:/Users/paclk/OneDrive - University of Reading/ug_project_data/Data/test_dask_RFFT/'
+dir = 'C:/Users\paclk\OneDrive - University of Reading/traj_data/CBL/test_dask_RFFT/'
+#file = 'diagnostics_ts_4784400.0.nc'
+#file = 'diagnostics_ts_18000.0.nc'
+#file = 'diagnostics_3d_ts_21600.nc'
+#file = 'diagnostics_3d_ts_21600_test_dask.nc'
+#file = 'diagnostics_3d_ts_21600_test_dask_filter_ga00.nc'
+file = 'diagnostics_3d_ts_13200_test_dask_filter_ga00.nc'
+
+dataset = xr.open_dataset(dir+file,chunks={'time':1,'i':1,'j':1,
+                                                'x_p':160, 'y_p':160,
+                                                'z':'auto'})
+print(dataset)
+
+dataset.close()
+
+
+dataset = Dataset(dir+file, 'r') # Dataset is the class behavior to open the file
+                                 # and create an instance of the ncCDF4 class
+
+nc_attrs, nc_dims, nc_vars = ncdump(dataset,verb=True)
+
+dataset.close()
+
+


### PR DESCRIPTION
I have converted to use xarray; this simplifies much of the code and also facilitates the use of dask to parallelize the processing.
Of note:
-  get_data enhanced to provide true grids, at least for primary data (so we now have x_p, x_u, y_v as well as z and zn as coords). **Q for reviewers:** do we still need '_on_w' etc. appended to variable name. This makes access quicker but loses some of the xarray benefits.
- dask is sensitive to chunking - I have only tested on my laptop. Beware small chunks - I managed to slow doen processing of a small file by a factor of 10! **Note for reviewers**: experiment with sf.subfilter_setup['chunk_size':] - currently 2**22 numbers.
- dask can also get its knickers in a twist saving one field after another - I added a 3 second pause after each which seems to solve the issue. ** Note for reviewers**: experiment with sf.subfilter_setup['write_sleeptime].
- I have saved deformation as a 5D array (time, x, y, z, i, j) - this gets very big (25 GB with George's data) and netCDF access doesn't like the size. xarray/dask works fine with output. However, an alternative is my original solution, to save 9 arrays and keep in memory as a dictionary. I have partially implemented this. **Q for reviewers**: which do you prefer?
- Alanna - see new version of your main program.